### PR TITLE
fix: check bluetooth enabled before accessing to avoid crash

### DIFF
--- a/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.pl.resx
+++ b/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.pl.resx
@@ -318,6 +318,9 @@
   <data name="PermissionLocationRequired" xml:space="preserve">
     <value>Do skanowania wymagane jest pozwolenie na korzystanie z funkcji Lokalizacji (Bluetooth).</value>
   </data>
+  <data name="BluetoothDisabled" xml:space="preserve">
+    <value>Bluetooth jest wyłączony. Włącz Bluetooth, aby skanować wagę Mi Scale.</value>
+  </data>
   <data name="Problem" xml:space="preserve">
     <value>Problem</value>
   </data>

--- a/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.resx
+++ b/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.resx
@@ -318,6 +318,9 @@
   <data name="PermissionLocationRequired" xml:space="preserve">
     <value>Permission to use Location (Bluetooth) is required to scan.</value>
   </data>
+  <data name="BluetoothDisabled" xml:space="preserve">
+    <value>Bluetooth is disabled. Please enable Bluetooth to scan for your Mi Scale.</value>
+  </data>
   <data name="Problem" xml:space="preserve">
     <value>Problem</value>
   </data>

--- a/src/MiScaleExporter.MAUI/ViewModels/ScaleViewModel.cs
+++ b/src/MiScaleExporter.MAUI/ViewModels/ScaleViewModel.cs
@@ -2,6 +2,8 @@
 using MiScaleExporter.Services;
 using MiScaleExporter.Permission;
 using MiScaleExporter.MAUI.Resources.Localization;
+using Plugin.BLE;
+using Plugin.BLE.Abstractions;
 
 namespace MiScaleExporter.MAUI.ViewModels
 {
@@ -98,6 +100,16 @@ namespace MiScaleExporter.MAUI.ViewModels
                     }
                 }
 
+            }
+
+            // Check if Bluetooth is enabled
+            if (CrossBluetoothLE.Current.State != BluetoothState.On)
+            {
+                await Application.Current.MainPage.DisplayAlert(
+                    AppSnippets.Problem,
+                    AppSnippets.BluetoothDisabled,
+                    AppSnippets.OK);
+                return false;
             }
 
             return true;


### PR DESCRIPTION
The app has crashed a couple of times now, and I didn't understand why—until I realized it happens when Bluetooth is turned off.

Looking at the code, I saw that it checks for permissions but doesn't check whether Bluetooth is actually enabled.
This PR adds that check + an alert prompting the user to turn on Bluetooth.