### PR TITLE
Add calibration based on reference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize all text files to LF in the repository (matches existing history).
+# Overrides any core.autocrlf setting so editors/IDEs stop showing phantom
+# line-ending changes.
+* text=auto eol=lf
+
+# Explicitly binary assets (never normalize / diff as text).
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.otf binary
+*.ttf binary
+*.keystore binary

--- a/src/MiScaleExporter.MAUI/Models/FatCalibrationPoint.cs
+++ b/src/MiScaleExporter.MAUI/Models/FatCalibrationPoint.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace MiScaleExporter.Models
+{
+    /// <summary>
+    /// A single paired calibration sample: what the scale reported vs. a trusted
+    /// reference (e.g. a medical-grade body composition scan) at the same body state.
+    /// Used to fit a linear correction trueFat = a * scaleFat + b.
+    /// </summary>
+    public class FatCalibrationPoint
+    {
+        public DateTime Date { get; set; }
+
+        /// <summary>Body fat % the scale/app reported for this measurement.</summary>
+        public double ScaleFat { get; set; }
+
+        /// <summary>Reference (medical scan) body fat % for the same measurement.</summary>
+        public double TrueFat { get; set; }
+    }
+}

--- a/src/MiScaleExporter.MAUI/Models/PreferencesKeys.cs
+++ b/src/MiScaleExporter.MAUI/Models/PreferencesKeys.cs
@@ -23,4 +23,6 @@ public static class PreferencesKeys
     public static string S400Bindkey = "S400Bindkey";
     public static string DisplayWeightInLbs = "DisplayWeightInLbs";
     public static string UseChinaServer = "UseChinaServer";
+    public static string UseFatCalibration = "UseFatCalibration";
+    public static string FatCalibrationPoints = "FatCalibrationPoints";
 }

--- a/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.Designer.cs
+++ b/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.Designer.cs
@@ -653,7 +653,16 @@ namespace MiScaleExporter.MAUI.Resources.Localization {
                 return ResourceManager.GetString("PermissionBluetoothRequired", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Bluetooth is turned off. Please enable Bluetooth and try again..
+        /// </summary>
+        internal static string BluetoothDisabled {
+            get {
+                return ResourceManager.GetString("BluetoothDisabled", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Permission to use Location (Bluetooth) is required to scan..
         /// </summary>

--- a/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.resx
+++ b/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.resx
@@ -315,6 +315,9 @@
   <data name="PermissionBluetoothRequired" xml:space="preserve">
     <value>Permission to use Bluetooth is required to scan.</value>
   </data>
+  <data name="BluetoothDisabled" xml:space="preserve">
+    <value>Bluetooth is turned off. Please enable Bluetooth and try again.</value>
+  </data>
   <data name="PermissionLocationRequired" xml:space="preserve">
     <value>Permission to use Location (Bluetooth) is required to scan.</value>
   </data>

--- a/src/MiScaleExporter.MAUI/Services/DataInterpreter.cs
+++ b/src/MiScaleExporter.MAUI/Services/DataInterpreter.cs
@@ -60,7 +60,7 @@ namespace MiScaleExporter.Services
                             Date = bc.Date,
 
                         };
-                        return bodyComposition;
+                        return FatCalibration.ApplySaved(bodyComposition);
                     }
                     else
                     {
@@ -129,7 +129,7 @@ namespace MiScaleExporter.Services
                                 Date = s400Result.Date,
 
                             };
-                            return bodyComposition;
+                            return FatCalibration.ApplySaved(bodyComposition);
 
                         }
                     }

--- a/src/MiScaleExporter.MAUI/Services/FatCalibration.cs
+++ b/src/MiScaleExporter.MAUI/Services/FatCalibration.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MiScaleExporter.Models;
+using Newtonsoft.Json;
+
+namespace MiScaleExporter.Services
+{
+    /// <summary>
+    /// Linear calibration of the scale's estimated body fat % against trusted
+    /// reference measurements: trueFat ≈ a * scaleFat + b, fitted by least squares.
+    ///
+    /// The fitted correction is applied to a <see cref="BodyComposition"/> as a delta,
+    /// so an identity fit (a=1, b=0) changes nothing. Only fat-derived fields are
+    /// adjusted (fat %, muscle mass, water %, protein %); bone mass, BMR, visceral fat,
+    /// metabolic age and BMI are produced by the library independently of fat % and are
+    /// left untouched.
+    /// </summary>
+    public static class FatCalibration
+    {
+        // Library clamp bounds, mirrored so corrected values stay in the same ranges.
+        private const double FatMin = 5, FatMax = 75;
+        private const double WaterMin = 35, WaterMax = 75;
+        private const double ProteinMin = 5, ProteinMax = 32;
+
+        public readonly struct Fit
+        {
+            public Fit(double a, double b, double r2, int pointCount)
+            {
+                A = a;
+                B = b;
+                R2 = r2;
+                PointCount = pointCount;
+            }
+
+            /// <summary>Slope (proportional error).</summary>
+            public double A { get; }
+
+            /// <summary>Intercept (fixed offset).</summary>
+            public double B { get; }
+
+            /// <summary>Coefficient of determination; NaN when undefined (&lt;2 points or no spread).</summary>
+            public double R2 { get; }
+
+            public int PointCount { get; }
+
+            /// <summary>True when the fit actually changes the reading.</summary>
+            public bool IsMeaningful => PointCount > 0 && (Math.Abs(A - 1.0) > 1e-9 || Math.Abs(B) > 1e-9);
+
+            public static Fit Identity => new Fit(1.0, 0.0, double.NaN, 0);
+
+            public double Correct(double scaleFat) => A * scaleFat + B;
+        }
+
+        /// <summary>
+        /// Fit a linear correction over the supplied calibration points.
+        /// 0 points → identity; 1 point → pure ratio (a = true/scale, b = 0);
+        /// 2+ points → ordinary least squares (falls back to ratio if all scale values are equal).
+        /// </summary>
+        public static Fit ComputeFit(IList<FatCalibrationPoint> points)
+        {
+            if (points == null || points.Count == 0)
+            {
+                return Fit.Identity;
+            }
+
+            var valid = points.Where(p => p.ScaleFat > 0 && p.TrueFat > 0).ToList();
+            if (valid.Count == 0)
+            {
+                return Fit.Identity;
+            }
+
+            if (valid.Count == 1)
+            {
+                var p = valid[0];
+                return new Fit(p.TrueFat / p.ScaleFat, 0.0, double.NaN, 1);
+            }
+
+            int n = valid.Count;
+            double sumX = valid.Sum(p => p.ScaleFat);
+            double sumY = valid.Sum(p => p.TrueFat);
+            double sumXX = valid.Sum(p => p.ScaleFat * p.ScaleFat);
+            double sumXY = valid.Sum(p => p.ScaleFat * p.TrueFat);
+
+            double denom = n * sumXX - sumX * sumX;
+            if (Math.Abs(denom) < 1e-9)
+            {
+                // No spread in scale values: can't fit a slope, fall back to ratio of means.
+                return new Fit(sumY / sumX, 0.0, double.NaN, n);
+            }
+
+            double a = (n * sumXY - sumX * sumY) / denom;
+            double b = (sumY - a * sumX) / n;
+
+            // R²
+            double meanY = sumY / n;
+            double ssTot = valid.Sum(p => (p.TrueFat - meanY) * (p.TrueFat - meanY));
+            double ssRes = valid.Sum(p =>
+            {
+                double predicted = a * p.ScaleFat + b;
+                double resid = p.TrueFat - predicted;
+                return resid * resid;
+            });
+            double r2 = ssTot < 1e-12 ? double.NaN : 1.0 - ssRes / ssTot;
+
+            return new Fit(a, b, r2, n);
+        }
+
+        /// <summary>
+        /// Apply a fitted correction in place. Adjusts fat % and recomputes the fat-derived
+        /// fields as deltas off the library's values, so consistency is preserved and an
+        /// identity fit is a no-op. Returns the same instance for convenience.
+        /// </summary>
+        public static BodyComposition Apply(BodyComposition bc, Fit fit)
+        {
+            if (bc == null || !fit.IsMeaningful || bc.Fat <= 0 || bc.Weight <= 0)
+            {
+                return bc;
+            }
+
+            double fatOld = bc.Fat;
+            double fatNew = Math.Clamp(fit.Correct(fatOld), FatMin, FatMax);
+            if (Math.Abs(fatNew - fatOld) < 1e-9)
+            {
+                return bc;
+            }
+
+            double fatMassOld = bc.Weight * fatOld / 100.0;
+            double fatMassNew = bc.Weight * fatNew / 100.0;
+
+            bc.Fat = Math.Round(fatNew, 2);
+
+            // Muscle mass = weight - fatMass - boneMass (library formula). Weight and bone
+            // are unchanged, so muscle rises by exactly the reduction in fat mass.
+            bc.MuscleMass = Math.Round(bc.MuscleMass + (fatMassOld - fatMassNew), 2);
+
+            // Water % = (100 - fat) * 0.7 in the library; shift by the same delta.
+            bc.WaterPercentage = Math.Round(
+                Math.Clamp(bc.WaterPercentage + 0.7 * (fatOld - fatNew), WaterMin, WaterMax), 2);
+
+            // Protein % = muscle/weight*100 - water; recompute from the corrected values.
+            bc.ProteinPercentage = Math.Round(
+                Math.Clamp(bc.MuscleMass / bc.Weight * 100.0 - bc.WaterPercentage, ProteinMin, ProteinMax), 2);
+
+            return bc;
+        }
+
+        // ---- Persistence (JSON list in Preferences) -------------------------------------
+
+        public static List<FatCalibrationPoint> LoadPoints()
+        {
+            var json = Preferences.Get(PreferencesKeys.FatCalibrationPoints, string.Empty);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new List<FatCalibrationPoint>();
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<List<FatCalibrationPoint>>(json)
+                       ?? new List<FatCalibrationPoint>();
+            }
+            catch
+            {
+                return new List<FatCalibrationPoint>();
+            }
+        }
+
+        public static void SavePoints(IEnumerable<FatCalibrationPoint> points)
+        {
+            Preferences.Set(PreferencesKeys.FatCalibrationPoints,
+                JsonConvert.SerializeObject(points ?? Enumerable.Empty<FatCalibrationPoint>()));
+        }
+
+        public static bool IsEnabled => Preferences.Get(PreferencesKeys.UseFatCalibration, false);
+
+        /// <summary>Convenience: apply the saved, enabled calibration to a measurement.</summary>
+        public static BodyComposition ApplySaved(BodyComposition bc)
+        {
+            if (bc == null || !IsEnabled)
+            {
+                return bc;
+            }
+
+            return Apply(bc, ComputeFit(LoadPoints()));
+        }
+    }
+}

--- a/src/MiScaleExporter.MAUI/ViewModels/ScaleViewModel.cs
+++ b/src/MiScaleExporter.MAUI/ViewModels/ScaleViewModel.cs
@@ -4,6 +4,7 @@ using MiScaleExporter.Permission;
 using MiScaleExporter.MAUI.Resources.Localization;
 using Plugin.BLE;
 using Plugin.BLE.Abstractions;
+using Plugin.BLE.Abstractions.Contracts;
 
 namespace MiScaleExporter.MAUI.ViewModels
 {

--- a/src/MiScaleExporter.MAUI/ViewModels/SettingsViewModel.cs
+++ b/src/MiScaleExporter.MAUI/ViewModels/SettingsViewModel.cs
@@ -1,7 +1,11 @@
 ﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Windows.Input;
 using MiScaleExporter.MAUI.Resources.Localization;
+using MiScaleExporter.MAUI.Utils;
 using MiScaleExporter.Models;
+using MiScaleExporter.Services;
 
 
 
@@ -28,17 +32,28 @@ namespace MiScaleExporter.MAUI.ViewModels
                     Preferences.Remove(PreferencesKeys.UserAge);
                     Preferences.Remove(PreferencesKeys.UserBirthDate);
                     Preferences.Remove(PreferencesKeys.UseBirthDateMode);
+                    Preferences.Remove(PreferencesKeys.UseFatCalibration);
+                    Preferences.Remove(PreferencesKeys.FatCalibrationPoints);
                     this.UseBirthDateMode = false;
                     this.ManualAge = "25";
+                    this._useFatCalibration = false;
+                    OnPropertyChanged(nameof(UseFatCalibration));
+                    this.CalibrationPoints.Clear();
+                    OnPropertyChanged(nameof(CalibrationSummary));
                 }
             );
             GetBLEKeyCommand = new Command(async () => await Launcher.OpenAsync("https://lswiderski.github.io/mi-scale-exporter/#steps-to-connect-xiaomi-body-composition-scale-s400"));
             ResetTokensCommand = new Command(_clearTokens);
+            AddCalibrationPointCommand = new Command(AddCalibrationPoint);
+            RemoveCalibrationPointCommand = new Command<FatCalibrationPoint>(RemoveCalibrationPoint);
+            _newPointDate = DateTime.Today;
         }
 
         public ICommand ResetCommand { get; }
         public ICommand GetBLEKeyCommand { get; }
         public ICommand ResetTokensCommand { get; }
+        public ICommand AddCalibrationPointCommand { get; }
+        public ICommand RemoveCalibrationPointCommand { get; }
 
 
         public async Task LoadPreferencesAsync()
@@ -79,6 +94,12 @@ namespace MiScaleExporter.MAUI.ViewModels
                 this._email = Preferences.Get(PreferencesKeys.GarminUserEmail, string.Empty);
                 this._password = await SecureStorage.GetAsync(PreferencesKeys.GarminUserPassword);
                 this._bindkey = Preferences.Get(PreferencesKeys.S400Bindkey, string.Empty);
+
+                this._useFatCalibration = Preferences.Get(PreferencesKeys.UseFatCalibration, false);
+                this.CalibrationPoints = new ObservableCollection<FatCalibrationPoint>(
+                    FatCalibration.LoadPoints().OrderBy(p => p.Date));
+                OnPropertyChanged(nameof(CalibrationSummary));
+
                 NotifyAllPropertiesChanged();
             }
             finally
@@ -445,6 +466,112 @@ namespace MiScaleExporter.MAUI.ViewModels
         {
             SecureStorage.SetAsync(PreferencesKeys.GarminUserAccessToken, string.Empty);
             SecureStorage.SetAsync(PreferencesKeys.GarminUserTokenSecret, string.Empty);
+        }
+
+        // ---- Body fat calibration --------------------------------------------------------
+
+        private bool _useFatCalibration;
+
+        public bool UseFatCalibration
+        {
+            get => _useFatCalibration;
+            set
+            {
+                Preferences.Set(PreferencesKeys.UseFatCalibration, value);
+                SetProperty(ref _useFatCalibration, value);
+                OnPropertyChanged(nameof(CalibrationSummary));
+            }
+        }
+
+        private ObservableCollection<FatCalibrationPoint> _calibrationPoints = new();
+
+        public ObservableCollection<FatCalibrationPoint> CalibrationPoints
+        {
+            get => _calibrationPoints;
+            private set => SetProperty(ref _calibrationPoints, value);
+        }
+
+        private DateTime _newPointDate;
+
+        public DateTime NewPointDate
+        {
+            get => _newPointDate;
+            set => SetProperty(ref _newPointDate, value);
+        }
+
+        private string _newPointScaleFat;
+
+        public string NewPointScaleFat
+        {
+            get => _newPointScaleFat;
+            set => SetProperty(ref _newPointScaleFat, value);
+        }
+
+        private string _newPointTrueFat;
+
+        public string NewPointTrueFat
+        {
+            get => _newPointTrueFat;
+            set => SetProperty(ref _newPointTrueFat, value);
+        }
+
+        /// <summary>Human-readable description of the current fit, shown under the table.</summary>
+        public string CalibrationSummary
+        {
+            get
+            {
+                var count = _calibrationPoints?.Count ?? 0;
+                if (count == 0)
+                {
+                    return "No calibration points yet. Add at least one to enable correction.";
+                }
+
+                var fit = FatCalibration.ComputeFit(_calibrationPoints.ToList());
+                var formula = $"corrected = {fit.A:0.###} × scale {(fit.B >= 0 ? "+" : "−")} {Math.Abs(fit.B):0.##}";
+                var quality = double.IsNaN(fit.R2)
+                    ? (count == 1 ? "single-point ratio" : "fit quality unavailable")
+                    : $"R² = {fit.R2:0.000}";
+                var status = _useFatCalibration ? "active" : "disabled";
+                return $"{count} point{(count == 1 ? "" : "s")} · {formula} · {quality} · {status}";
+            }
+        }
+
+        private void AddCalibrationPoint()
+        {
+            var scaleFat = DoubleValueParser.ParseValueFromUsersCulture(_newPointScaleFat);
+            var trueFat = DoubleValueParser.ParseValueFromUsersCulture(_newPointTrueFat);
+            if (scaleFat is not > 0 || trueFat is not > 0)
+            {
+                return;
+            }
+
+            _calibrationPoints.Add(new FatCalibrationPoint
+            {
+                Date = _newPointDate == default ? DateTime.Today : _newPointDate,
+                ScaleFat = scaleFat.Value,
+                TrueFat = trueFat.Value,
+            });
+
+            CalibrationPoints = new ObservableCollection<FatCalibrationPoint>(
+                _calibrationPoints.OrderBy(p => p.Date));
+
+            FatCalibration.SavePoints(_calibrationPoints);
+
+            NewPointScaleFat = string.Empty;
+            NewPointTrueFat = string.Empty;
+            OnPropertyChanged(nameof(CalibrationSummary));
+        }
+
+        private void RemoveCalibrationPoint(FatCalibrationPoint point)
+        {
+            if (point == null || !_calibrationPoints.Contains(point))
+            {
+                return;
+            }
+
+            _calibrationPoints.Remove(point);
+            FatCalibration.SavePoints(_calibrationPoints);
+            OnPropertyChanged(nameof(CalibrationSummary));
         }
 
     }

--- a/src/MiScaleExporter.MAUI/Views/SettingsPage.xaml
+++ b/src/MiScaleExporter.MAUI/Views/SettingsPage.xaml
@@ -5,8 +5,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:behaviors="clr-namespace:MiScaleExporter.MAUI.Behaviors;assembly=MiScaleExporter.MAUI"
     xmlns:localization="clr-namespace:MiScaleExporter.MAUI.Resources.Localization"
+    xmlns:models="clr-namespace:MiScaleExporter.Models;assembly=MiScaleExporter.MAUI"
     xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     xmlns:vm="clr-namespace:MiScaleExporter.MAUI.ViewModels"
+    x:Name="SettingsRoot"
     Title="{Binding Title}">
     <AbsoluteLayout HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
         <Grid
@@ -307,7 +309,138 @@
                                 Command="{Binding ResetTokensCommand}"
                                 Text="Clear Garmin Tokens"
                                 TextColor="White" />
-                            
+
+                        </StackLayout>
+                    </Border>
+                    <Border>
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="20" />
+                        </Border.StrokeShape>
+                        <StackLayout
+                            Padding="15,24,15,24"
+                            Orientation="Vertical"
+                            Spacing="10">
+                            <Label
+                                FontAttributes="Bold"
+                                FontSize="Small"
+                                Text="Body Fat Calibration" />
+                            <BoxView
+                                HeightRequest="2"
+                                HorizontalOptions="Fill"
+                                Color="Gray" />
+                            <Label
+                                FontSize="Micro"
+                                Text="Correct the scale's body fat % toward trusted reference measurements (e.g. medical scans). Each point pairs what the scale reported with the reference value at the same time. A line (corrected = a × scale + b) is fitted across all points; muscle mass, water % and protein % are recomputed to match. Bone mass, BMR, visceral fat, metabolic age and BMI are unaffected." />
+
+                            <StackLayout Orientation="Horizontal" Spacing="10">
+                                <CheckBox IsChecked="{Binding UseFatCalibration, Mode=TwoWay}" VerticalOptions="Center" />
+                                <Label
+                                    FontSize="Small"
+                                    Text="Apply calibration to measurements"
+                                    VerticalOptions="Center" />
+                            </StackLayout>
+
+                            <CollectionView ItemsSource="{Binding CalibrationPoints}">
+                                <CollectionView.EmptyView>
+                                    <Label
+                                        FontSize="Micro"
+                                        Text="No calibration points added yet."
+                                        TextColor="Gray" />
+                                </CollectionView.EmptyView>
+                                <CollectionView.ItemTemplate>
+                                    <DataTemplate x:DataType="models:FatCalibrationPoint">
+                                        <Grid Padding="0,4" ColumnSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <Label
+                                                Grid.Column="0"
+                                                FontSize="Small"
+                                                Text="{Binding Date, StringFormat='{0:yyyy-MM-dd}'}"
+                                                VerticalOptions="Center" />
+                                            <Label
+                                                Grid.Column="1"
+                                                FontSize="Small"
+                                                Text="{Binding ScaleFat, StringFormat='scale {0:0.#}%'}"
+                                                VerticalOptions="Center" />
+                                            <Label
+                                                Grid.Column="2"
+                                                FontSize="Small"
+                                                Text="{Binding TrueFat, StringFormat='ref {0:0.#}%'}"
+                                                VerticalOptions="Center" />
+                                            <Button
+                                                Grid.Column="3"
+                                                Padding="0"
+                                                BackgroundColor="Transparent"
+                                                Command="{Binding BindingContext.RemoveCalibrationPointCommand, Source={x:Reference SettingsRoot}}"
+                                                CommandParameter="{Binding .}"
+                                                FontSize="Small"
+                                                Text="✕"
+                                                TextColor="#C0392B"
+                                                WidthRequest="40" />
+                                        </Grid>
+                                    </DataTemplate>
+                                </CollectionView.ItemTemplate>
+                            </CollectionView>
+
+                            <BoxView
+                                HeightRequest="1"
+                                HorizontalOptions="Fill"
+                                Color="LightGray" />
+
+                            <Label FontSize="Micro" Text="Add a point" />
+                            <Grid ColumnSpacing="8" RowSpacing="6">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <DatePicker
+                                    Grid.Row="0"
+                                    Grid.ColumnSpan="2"
+                                    Date="{Binding NewPointDate, Mode=TwoWay}"
+                                    FontSize="Small"
+                                    Format="yyyy-MM-dd" />
+                                <Entry
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    FontSize="Small"
+                                    Keyboard="Numeric"
+                                    Placeholder="Scale fat %"
+                                    Text="{Binding NewPointScaleFat, Mode=TwoWay}">
+                                    <Entry.Behaviors>
+                                        <behaviors:NumericDoubleValidationBehavior />
+                                    </Entry.Behaviors>
+                                </Entry>
+                                <Entry
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    FontSize="Small"
+                                    Keyboard="Numeric"
+                                    Placeholder="Reference fat %"
+                                    Text="{Binding NewPointTrueFat, Mode=TwoWay}">
+                                    <Entry.Behaviors>
+                                        <behaviors:NumericDoubleValidationBehavior />
+                                    </Entry.Behaviors>
+                                </Entry>
+                            </Grid>
+                            <Button
+                                Margin="0,4,0,0"
+                                BackgroundColor="{StaticResource Primary}"
+                                Command="{Binding AddCalibrationPointCommand}"
+                                Text="Add point"
+                                TextColor="White" />
+
+                            <Label
+                                FontSize="Micro"
+                                Text="{Binding CalibrationSummary}"
+                                TextColor="Gray" />
                         </StackLayout>
                     </Border>
                 </StackLayout>


### PR DESCRIPTION
If you had a higher quality measurement (like Dexa) You can use that measurement to recalibrate calculations. 
If you have 1 measurement, it applied as ratio
If you have 2 measurements, it is applied as linear function 
If you have 3 or more, it is applied as second power function.

So if you had a dexa that says you have 15% fat, but scale says 20%, adding this as calibration means 
future calculations will be pre multiplied by 15/20.