### PR TITLE
Complete S400 Garmin export and fix skeletal muscle labeling

### DIFF
--- a/MiScaleExporter.sln
+++ b/MiScaleExporter.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiScaleExporter.MAUI", "src\MiScaleExporter.MAUI\MiScaleExporter.MAUI.csproj", "{39C1BB45-DB3C-4C1A-A3C0-5CBB35C753D0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MiScaleExporter.UnitTests", "tests\MiScaleExporter.UnitTests\MiScaleExporter.UnitTests.csproj", "{D4E8FCD4-C9AA-4D4A-A384-33E2BE5394E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{39C1BB45-DB3C-4C1A-A3C0-5CBB35C753D0}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{39C1BB45-DB3C-4C1A-A3C0-5CBB35C753D0}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{39C1BB45-DB3C-4C1A-A3C0-5CBB35C753D0}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
+		{D4E8FCD4-C9AA-4D4A-A384-33E2BE5394E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4E8FCD4-C9AA-4D4A-A384-33E2BE5394E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4E8FCD4-C9AA-4D4A-A384-33E2BE5394E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4E8FCD4-C9AA-4D4A-A384-33E2BE5394E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Tested on Oneplus 5T (Android 10) and Mi Body Composition Scale (XMTZC02HM)
 
 Check out this web project: https://github.com/lswiderski/WebBodyComposition
 
+## Xiaomi S400 dual-frequency support
+
+The S400 integration uses [Xiaomi.BodyComposition.S400](https://github.com/jomzxc/MiScaleBodyComposition) to pair its separate 50 kHz and 250 kHz impedance advertisements before calculating body composition. The S400 skeletal muscle mass is sent through Garmin's native muscle-mass field, and BMR is sent through the native basal-metabolism field.
+
+Garmin weight records do not support protein, ideal weight, total muscle mass, heart rate, impedance, lean body mass, extracellular or intracellular water, ECW/TBW ratio, or body cell mass. Those values remain visible locally and are not included in Garmin uploads. The calculations follow the dual-frequency model documented by [dckiller51/bodymiscale](https://github.com/dckiller51/bodymiscale/blob/main/README_S400_UPGRADE.md). They are estimates for personal trend tracking, not clinical measurements or medical advice.
+
 ## Instruction
 
 - Stand on your scale. Measure yourself. Complete the user form data, Scale Bluetooth address and get data from the scale. Mi Body Composition Scale is active up to 15 min after the measurement. (Bluetooth address can be found in Zepp Life > Profile > My devices > Mi Body Composition Scale > Bluetooth address (hold to copy)).
@@ -87,6 +93,18 @@ sequenceDiagram
 - Plugin.BLE - To receive data via Bluetooth from Mi scale
 - Xamarin.Essentials
 - API Backend in C# (YAGCC project)
+
+## Dependency release prerequisites
+
+This branch targets `Xiaomi.BodyComposition.S400` 1.1.1 and `YetAnotherGarminConnectClient` 0.0.18. Publish those packages before building from a clean clone. The dependency changes are preserved in [`patches/xiaomi-s400-1.1.1-release.patch`](patches/xiaomi-s400-1.1.1-release.patch) and [`patches/yagcc-basal-met.patch`](patches/yagcc-basal-met.patch).
+
+For local source development, package references can be replaced explicitly without relying on sibling-directory discovery:
+
+```powershell
+dotnet build src/MiScaleExporter.MAUI/MiScaleExporter.MAUI.csproj `
+  -p:XiaomiBodyCompositionS400Project=C:\path\to\MiScaleBodyComposition.csproj `
+  -p:YetAnotherGarminConnectClientProject=C:\path\to\YetAnotherGarminConnectClient.csproj
+```
 
 ## Images
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,9 @@ It also allows you to upload manually entered body composition data to the Garmi
    
    [![Watch the video](https://img.youtube.com/vi/HtOZZwnkZHw/0.jpg)](https://www.youtube.com/shorts/HtOZZwnkZHw)
 
-6. These types of scales do not measure body composition. They measure weight and impedance and estimate the result based on those measurements. The scale sends 3 values: Weight, impedance and Heart rate. To receive body composition data, impedance is processed by an algorithm known to be similar to that used by the Mi Body Composition Scale 2 (different from that used by the S400). Because of this, the result may differ from that of the Xiaomi Home app. For this calculation proper age, height and sex is needed.
+6. The S400 sends weight, separate 50 kHz and 250 kHz impedance readings, and optional heart rate. MiScale Exporter uses [Xiaomi.BodyComposition.S400](https://github.com/jomzxc/MiScaleBodyComposition) to wait for both impedance advertisements and calculate fat, water, protein, BMR, metabolic age, lean body mass, extracellular and intracellular water, ECW/TBW ratio, body cell mass, and skeletal muscle mass. Proper age, height, and sex are required. BMR and skeletal muscle mass use Garmin's native weight fields. Protein, ideal weight, total muscle mass, heart rate, impedance, lean body mass, water compartments, ECW/TBW ratio, and body cell mass remain local because Garmin has no native weight fields for them.
+
+   The model follows the formulas documented by [dckiller51/bodymiscale](https://github.com/dckiller51/bodymiscale/blob/main/README_S400_UPGRADE.md). Dual-frequency foot-to-foot BIA values are estimates for personal trend tracking and should not be treated as clinical measurements or medical advice.
 
 7. Bear in mind that it is an experimental solution and errors may occur. If you encounter them, please contact me.
 

--- a/patches/xiaomi-s400-1.1.1-release.patch
+++ b/patches/xiaomi-s400-1.1.1-release.patch
@@ -1,0 +1,22 @@
+diff --git a/src/MiScaleBodyComposition.csproj b/src/MiScaleBodyComposition.csproj
+--- a/src/MiScaleBodyComposition.csproj
++++ b/src/MiScaleBodyComposition.csproj
+@@ -7,5 +7,5 @@
+     <RootNamespace>Xiaomi.BodyComposition.S400</RootNamespace>
+     <Company>jomszxc</Company>
+-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+-    <FileVersion>1.1.0.0</FileVersion>
++    <AssemblyVersion>1.1.1.0</AssemblyVersion>
++    <FileVersion>1.1.1.0</FileVersion>
+     <PackageId>Xiaomi.BodyComposition.S400</PackageId>
+@@ -18,3 +18,3 @@
+     <PackageReadmeFile>README.md</PackageReadmeFile>
+-    <PackageReleaseNotes>S400-only release with dual-frequency impedance pairing and full S400 body-composition metrics. Legacy Xiaomi scale implementations have been removed.</PackageReleaseNotes>
++    <PackageReleaseNotes>Corrects the package assembly identity and includes dual-frequency S400 metrics and heart rate.</PackageReleaseNotes>
+     <RepositoryUrl>https://github.com/jomzxc/Xiaomi.BodyComposition.S400</RepositoryUrl>
+@@ -26,4 +26,4 @@
+     <RepositoryType>git</RepositoryType>
+     <PackageTags>xiaomi, s400, dual-frequency, bluetooth, ble, bodycomposition, impedance</PackageTags>
+-    <PackageVersion>1.1.0</PackageVersion>
++    <PackageVersion>1.1.1</PackageVersion>
+     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/patches/yagcc-basal-met.patch
+++ b/patches/yagcc-basal-met.patch
@@ -1,0 +1,106 @@
+diff --git a/src/Api/Contracts/BodyCompositionRequest.cs b/src/Api/Contracts/BodyCompositionRequest.cs
+--- a/src/Api/Contracts/BodyCompositionRequest.cs
++++ b/src/Api/Contracts/BodyCompositionRequest.cs
+@@ -15,4 +15,5 @@ namespace Api.Contracts
+         public float? PhysiqueRating { set; get; }
+         public float? MetabolicAge { set; get; }
+         public float? bodyMassIndex { get; set; }
++        public float? BasalMet { get; set; }
+         public bool CreateOnlyFile { get; set; } = false;
+diff --git a/src/Api/Endpoints/UploadEndpoints.cs b/src/Api/Endpoints/UploadEndpoints.cs
+--- a/src/Api/Endpoints/UploadEndpoints.cs
++++ b/src/Api/Endpoints/UploadEndpoints.cs
+@@ -62,3 +62,4 @@ public static class UploadEndpoints
+                     MetabolicAge = request.MetabolicAge.HasValue ? (byte)Math.Round(request.MetabolicAge.Value) : null,
+                     BodyMassIndex = request.bodyMassIndex,
++                    BasalMet = request.BasalMet,
+                 };
+diff --git a/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs b/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
+--- a/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
++++ b/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
+@@ -35,4 +35,5 @@ namespace YetAnotherGarminConnectClient.Dto.Garmin.Fit
+         public byte? PhysiqueRating { set; get; }
+         public byte? MetabolicAge { set; get; }
+         public float? BodyMassIndex { set; get; }
++        public float? BasalMet { set; get; }
+     }
+diff --git a/src/YetAnotherGarminConnectClient/FitFileCreator.cs b/src/YetAnotherGarminConnectClient/FitFileCreator.cs
+--- a/src/YetAnotherGarminConnectClient/FitFileCreator.cs
++++ b/src/YetAnotherGarminConnectClient/FitFileCreator.cs
+@@ -54,4 +54,6 @@ namespace YetAnotherGarminConnectClient
+                     weightMesg.SetPercentHydration(garminWeightScaleData.PercentHydration);
+                 if (garminWeightScaleData.MuscleMass is not null)
+                     weightMesg.SetMuscleMass(garminWeightScaleData.MuscleMass);
++                if (garminWeightScaleData.BasalMet is not null)
++                    weightMesg.SetBasalMet(garminWeightScaleData.BasalMet);
+                 if (garminWeightScaleData.BoneMass is not null)
+diff --git a/tests/Api/Helpers/BodyCompositionRequestBuilder.cs b/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
+--- a/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
++++ b/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
+@@ -41,3 +41,4 @@ namespace Api.Tests.Helpers
+                 MetabolicAge = 35,
+                 bodyMassIndex = 24.5f,
++                BasalMet = 1650f,
+                 TimeStamp = null,
+diff --git a/tests/FitFileCreatorTests.cs b/tests/FitFileCreatorTests.cs
+new file mode 100644
+--- /dev/null
++++ b/tests/FitFileCreatorTests.cs
+@@ -0,0 +1,57 @@
++using Dynastream.Fit;
++using NUnit.Framework;
++using YetAnotherGarminConnectClient.Dto.Garmin.Fit;
++
++namespace YetAnotherGarminConnectClient.Tests;
++
++[TestFixture]
++public class FitFileCreatorTests
++{
++    [Test]
++    public void WeightFitFileRoundTripsBasalMetAndMuscleMass()
++    {
++        var data = new GarminWeightScaleData
++        {
++            TimeStamp = new System.DateTime(2026, 7, 12, 8, 30, 0, DateTimeKind.Utc),
++            Weight = 74.2f,
++            MuscleMass = 40.0f,
++            BasalMet = 1650f,
++        };
++        var profile = new UserProfileSettings { Age = 29, Height = 182 };
++        var bytes = FitFileCreator.CreateWeightBodyCompositionFitFile(data, profile);
++        var decode = new Decode();
++        var broadcaster = new MesgBroadcaster();
++        WeightScaleMesg? decoded = null;
++        decode.MesgEvent += broadcaster.OnMesg;
++        broadcaster.WeightScaleMesgEvent += (_, args) => decoded = new WeightScaleMesg(args.mesg);
++        using var stream = new MemoryStream(bytes);
++
++        Assert.That(decode.Read(stream), Is.True);
++        Assert.That(decoded, Is.Not.Null);
++        Assert.That(decoded!.GetBasalMet(), Is.EqualTo(1650f).Within(0.25f));
++        Assert.That(decoded.GetMuscleMass(), Is.EqualTo(40.0f).Within(0.01f));
++    }
++
++    [Test]
++    public void WeightFitFileOmitsBasalMetWhenItIsNull()
++    {
++        var data = new GarminWeightScaleData
++        {
++            TimeStamp = new System.DateTime(2026, 7, 12, 8, 30, 0, DateTimeKind.Utc),
++            Weight = 74.2f,
++            BasalMet = null,
++        };
++        var profile = new UserProfileSettings { Age = 29, Height = 182 };
++        var bytes = FitFileCreator.CreateWeightBodyCompositionFitFile(data, profile);
++        var decode = new Decode();
++        var broadcaster = new MesgBroadcaster();
++        WeightScaleMesg? decoded = null;
++        decode.MesgEvent += broadcaster.OnMesg;
++        broadcaster.WeightScaleMesgEvent += (_, args) => decoded = new WeightScaleMesg(args.mesg);
++        using var stream = new MemoryStream(bytes);
++
++        Assert.That(decode.Read(stream), Is.True);
++        Assert.That(decoded, Is.Not.Null);
++        Assert.That(decoded!.GetBasalMet(), Is.Null);
++    }
++}

--- a/patches/yagcc-basal-met.patch
+++ b/patches/yagcc-basal-met.patch
@@ -1,52 +1,103 @@
 diff --git a/src/Api/Contracts/BodyCompositionRequest.cs b/src/Api/Contracts/BodyCompositionRequest.cs
+index 5b5cfac..33c0318 100644
 --- a/src/Api/Contracts/BodyCompositionRequest.cs
 +++ b/src/Api/Contracts/BodyCompositionRequest.cs
-@@ -15,4 +15,5 @@ namespace Api.Contracts
-         public float? PhysiqueRating { set; get; }
-         public float? MetabolicAge { set; get; }
-         public float? bodyMassIndex { get; set; }
+@@ -11,0 +12,3 @@ namespace Api.Contracts
++        public float? SkeletalMuscleMass { set; get; }
++
++        // Retained so older proxy clients continue to upload this value.
+@@ -17,0 +21 @@ namespace Api.Contracts
 +        public float? BasalMet { get; set; }
-         public bool CreateOnlyFile { get; set; } = false;
 diff --git a/src/Api/Endpoints/UploadEndpoints.cs b/src/Api/Endpoints/UploadEndpoints.cs
+index a60d2da..906a3a2 100644
 --- a/src/Api/Endpoints/UploadEndpoints.cs
 +++ b/src/Api/Endpoints/UploadEndpoints.cs
-@@ -62,3 +62,4 @@ public static class UploadEndpoints
-                     MetabolicAge = request.MetabolicAge.HasValue ? (byte)Math.Round(request.MetabolicAge.Value) : null,
-                     BodyMassIndex = request.bodyMassIndex,
+@@ -59 +59 @@ public static class UploadEndpoints
+-                    MuscleMass = request.MuscleMass,
++                    SkeletalMuscleMass = request.SkeletalMuscleMass ?? request.MuscleMass,
+@@ -64,0 +65 @@ public static class UploadEndpoints
 +                    BasalMet = request.BasalMet,
-                 };
+@@ -160 +161 @@ public static class UploadEndpoints
+-}
+\ No newline at end of file
++}
+diff --git a/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommand.cs b/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommand.cs
+index e14b3a9..1660117 100644
+--- a/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommand.cs
++++ b/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommand.cs
+@@ -45 +45 @@ namespace YAGCC.Commands.UploadBodyComposition
+-                    MuscleMass = request.MuscleMass,
++                    SkeletalMuscleMass = request.SkeletalMuscleMass,
+diff --git a/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommandSettings.cs b/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommandSettings.cs
+index d1caf15..ca45edf 100644
+--- a/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommandSettings.cs
++++ b/src/YAGCC/Commands/UploadBodyComposition/UploadBodyCompositionCommandSettings.cs
+@@ -29,3 +29,3 @@ namespace YAGCC.Commands.UploadBodyComposition
+-        [CommandOption("-m|--muscle-mass")]
+-        [Description("Set your muscle mass in kilograms")]
+-        public float? MuscleMass { set; get; }
++        [CommandOption("-m|--skeletal-muscle-mass|--muscle-mass")]
++        [Description("Set your skeletal muscle mass in kilograms")]
++        public float? SkeletalMuscleMass { set; get; }
 diff --git a/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs b/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
+index 4709333..de2ef07 100644
 --- a/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
 +++ b/src/YetAnotherGarminConnectClient/Dto/Garmin/Fit/Models.cs
-@@ -35,4 +35,5 @@ namespace YetAnotherGarminConnectClient.Dto.Garmin.Fit
-         public byte? PhysiqueRating { set; get; }
-         public byte? MetabolicAge { set; get; }
-         public float? BodyMassIndex { set; get; }
+@@ -32 +32,14 @@ namespace YetAnotherGarminConnectClient.Dto.Garmin.Fit
+-        public float? MuscleMass { set; get; }
++        /// <summary>
++        /// Skeletal muscle mass in kilograms. Garmin's FIT profile names this field muscle_mass.
++        /// </summary>
++        public float? SkeletalMuscleMass { set; get; }
++
++        /// <summary>
++        /// Backwards-compatible alias for <see cref="SkeletalMuscleMass"/>.
++        /// </summary>
++        [Obsolete("Use SkeletalMuscleMass. Garmin's muscle_mass FIT field represents skeletal muscle mass.")]
++        public float? MuscleMass
++        {
++            get => SkeletalMuscleMass;
++            set => SkeletalMuscleMass = value;
++        }
+@@ -37,0 +51 @@ namespace YetAnotherGarminConnectClient.Dto.Garmin.Fit
 +        public float? BasalMet { set; get; }
-     }
 diff --git a/src/YetAnotherGarminConnectClient/FitFileCreator.cs b/src/YetAnotherGarminConnectClient/FitFileCreator.cs
+index b259a44..3e860a8 100644
 --- a/src/YetAnotherGarminConnectClient/FitFileCreator.cs
 +++ b/src/YetAnotherGarminConnectClient/FitFileCreator.cs
-@@ -54,4 +54,6 @@ namespace YetAnotherGarminConnectClient
-                     weightMesg.SetPercentHydration(garminWeightScaleData.PercentHydration);
-                 if (garminWeightScaleData.MuscleMass is not null)
-                     weightMesg.SetMuscleMass(garminWeightScaleData.MuscleMass);
+@@ -55,2 +55,4 @@ namespace YetAnotherGarminConnectClient
+-                if (garminWeightScaleData.MuscleMass is not null)
+-                    weightMesg.SetMuscleMass(garminWeightScaleData.MuscleMass);
++                if (garminWeightScaleData.SkeletalMuscleMass is not null)
++                    weightMesg.SetMuscleMass(garminWeightScaleData.SkeletalMuscleMass);
 +                if (garminWeightScaleData.BasalMet is not null)
 +                    weightMesg.SetBasalMet(garminWeightScaleData.BasalMet);
-                 if (garminWeightScaleData.BoneMass is not null)
 diff --git a/tests/Api/Helpers/BodyCompositionRequestBuilder.cs b/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
+index c0975f6..15a2766 100644
 --- a/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
 +++ b/tests/Api/Helpers/BodyCompositionRequestBuilder.cs
-@@ -41,3 +41,4 @@ namespace Api.Tests.Helpers
-                 MetabolicAge = 35,
-                 bodyMassIndex = 24.5f,
+@@ -38 +38 @@ namespace Api.Tests.Helpers
+-                MuscleMass = 30.0f,
++                SkeletalMuscleMass = 30.0f,
+@@ -43,0 +44 @@ namespace Api.Tests.Helpers
 +                BasalMet = 1650f,
-                 TimeStamp = null,
+diff --git a/tests/ClientTests.cs b/tests/ClientTests.cs
+index 5834a63..586017e 100644
+--- a/tests/ClientTests.cs
++++ b/tests/ClientTests.cs
+@@ -37 +37 @@ namespace YetAnotherGarminConnectClient.Tests
+-                MuscleMass = 32f,
++                SkeletalMuscleMass = 32f,
+@@ -223 +223 @@ namespace YetAnotherGarminConnectClient.Tests
+-}
+\ No newline at end of file
++}
 diff --git a/tests/FitFileCreatorTests.cs b/tests/FitFileCreatorTests.cs
 new file mode 100644
+index 0000000..8e8151b
 --- /dev/null
 +++ b/tests/FitFileCreatorTests.cs
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,71 @@
 +using Dynastream.Fit;
 +using NUnit.Framework;
 +using YetAnotherGarminConnectClient.Dto.Garmin.Fit;
@@ -57,24 +108,26 @@ new file mode 100644
 +public class FitFileCreatorTests
 +{
 +    [Test]
-+    public void WeightFitFileRoundTripsBasalMetAndMuscleMass()
++    public void WeightFitFileRoundTripsBasalMetAndSkeletalMuscleMass()
 +    {
 +        var data = new GarminWeightScaleData
 +        {
 +            TimeStamp = new System.DateTime(2026, 7, 12, 8, 30, 0, DateTimeKind.Utc),
 +            Weight = 74.2f,
-+            MuscleMass = 40.0f,
++            SkeletalMuscleMass = 40.0f,
 +            BasalMet = 1650f,
 +        };
 +        var profile = new UserProfileSettings { Age = 29, Height = 182 };
++
 +        var bytes = FitFileCreator.CreateWeightBodyCompositionFitFile(data, profile);
 +        var decode = new Decode();
 +        var broadcaster = new MesgBroadcaster();
 +        WeightScaleMesg? decoded = null;
++
 +        decode.MesgEvent += broadcaster.OnMesg;
 +        broadcaster.WeightScaleMesgEvent += (_, args) => decoded = new WeightScaleMesg(args.mesg);
-+        using var stream = new MemoryStream(bytes);
 +
++        using var stream = new MemoryStream(bytes);
 +        Assert.That(decode.Read(stream), Is.True);
 +        Assert.That(decoded, Is.Not.Null);
 +        Assert.That(decoded!.GetBasalMet(), Is.EqualTo(1650f).Within(0.25f));
@@ -91,16 +144,35 @@ new file mode 100644
 +            BasalMet = null,
 +        };
 +        var profile = new UserProfileSettings { Age = 29, Height = 182 };
++
 +        var bytes = FitFileCreator.CreateWeightBodyCompositionFitFile(data, profile);
 +        var decode = new Decode();
 +        var broadcaster = new MesgBroadcaster();
 +        WeightScaleMesg? decoded = null;
++
 +        decode.MesgEvent += broadcaster.OnMesg;
 +        broadcaster.WeightScaleMesgEvent += (_, args) => decoded = new WeightScaleMesg(args.mesg);
-+        using var stream = new MemoryStream(bytes);
 +
++        using var stream = new MemoryStream(bytes);
 +        Assert.That(decode.Read(stream), Is.True);
 +        Assert.That(decoded, Is.Not.Null);
 +        Assert.That(decoded!.GetBasalMet(), Is.Null);
 +    }
++
++    [Test]
++    public void LegacyMuscleMassAliasPopulatesSkeletalMuscleMass()
++    {
++#pragma warning disable CS0618
++        var data = new GarminWeightScaleData { MuscleMass = 39.5f };
++#pragma warning restore CS0618
++
++        Assert.That(data.SkeletalMuscleMass, Is.EqualTo(39.5f));
++    }
 +}
+diff --git a/tests/GarminConnectClientTests.cs b/tests/GarminConnectClientTests.cs
+index d5a8a90..c198239 100644
+--- a/tests/GarminConnectClientTests.cs
++++ b/tests/GarminConnectClientTests.cs
+@@ -43 +43 @@ namespace YetAnotherGarminConnectClient.Tests
+-                MuscleMass = 32f,
++                SkeletalMuscleMass = 32f,

--- a/src/MiScaleExporter.MAUI/MiScaleExporter.MAUI.csproj
+++ b/src/MiScaleExporter.MAUI/MiScaleExporter.MAUI.csproj
@@ -89,13 +89,20 @@
 	  <PackageReference Include="Autofac.Extras.CommonServiceLocator" Version="6.1.0" />
 	  <PackageReference Include="CommunityToolkit.Maui" Version="12.1.0" />
 	  <PackageReference Include="MiScaleBodyComposition" Version="1.0.12" />
+	  <PackageReference Include="Xiaomi.BodyComposition.S400" Version="1.1.1" Condition="!Exists('$(XiaomiBodyCompositionS400Project)')" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	  <PackageReference Include="NLog" Version="5.3.1" />
 	  <PackageReference Include="NLog.Extensions.Logging" Version="5.3.9" />
 	  <PackageReference Include="Plugin.AdMob" Version="2.3.2-beta.7" />
 	  <PackageReference Include="Plugin.BLE" Version="3.2.0-beta.1" />
 	  <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-	  <PackageReference Include="YetAnotherGarminConnectClient" Version="0.0.17" />
+	  <PackageReference Include="YetAnotherGarminConnectClient" Version="0.0.18" Condition="!Exists('$(YetAnotherGarminConnectClientProject)')" />
+	</ItemGroup>
+	<ItemGroup Condition="Exists('$(XiaomiBodyCompositionS400Project)')">
+	  <ProjectReference Include="$(XiaomiBodyCompositionS400Project)" />
+	</ItemGroup>
+	<ItemGroup Condition="Exists('$(YetAnotherGarminConnectClientProject)')">
+	  <ProjectReference Include="$(YetAnotherGarminConnectClientProject)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MiScaleExporter.MAUI/Models/BodyComposition.cs
+++ b/src/MiScaleExporter.MAUI/Models/BodyComposition.cs
@@ -18,8 +18,18 @@ namespace MiScaleExporter.Models
         public double VisceralFat { get; set; }
         public int BodyType { get; set; }
         public double WaterPercentage { get; set; }
+        public double? ImpedanceLow { get; set; }
+        public double? ImpedanceHigh { get; set; }
+        public double? LeanBodyMass { get; set; }
+        public double? ExtracellularWater { get; set; }
+        public double? IntracellularWater { get; set; }
+        public double? EcwTbwRatio { get; set; }
+        public double? BodyCellMass { get; set; }
+        public double? SkeletalMuscleMass { get; set; }
+        public double? HeartRate { get; set; }
         public bool IsValid { get; set; }
         public bool HasImpedance { get; set; }
+        public bool HasDualFrequencyImpedance => ImpedanceLow.HasValue && ImpedanceHigh.HasValue && LeanBodyMass.HasValue;
         public bool IsStabilized { get; set; }
         public DateTime Date { get; set; }
         public byte[] ReceivedRawData { get; set; } 

--- a/src/MiScaleExporter.MAUI/Models/GarminBodyCompositionRequest.cs
+++ b/src/MiScaleExporter.MAUI/Models/GarminBodyCompositionRequest.cs
@@ -12,6 +12,7 @@ public record GarminBodyCompositionRequest
     public int PhysiqueRating { get; set; }
     public double MetabolicAge { get; set; }
     public double BodyMassIndex { get; set; }
+    public double? BasalMet { get; set; }
     public string Email { get; set; }
     public string Password { get; set; }
     public string ClientID { get; set; }

--- a/src/MiScaleExporter.MAUI/Models/GarminBodyCompositionRequest.cs
+++ b/src/MiScaleExporter.MAUI/Models/GarminBodyCompositionRequest.cs
@@ -7,6 +7,8 @@ public record GarminBodyCompositionRequest
     public double PercentFat { get; set; }
     public double PercentHydration { get; set; }
     public double BoneMass { get; set; }
+    public double SkeletalMuscleMass { get; set; }
+    // Sent during the proxy transition so servers on the older contract retain the value.
     public double MuscleMass { get; set; }
     public double VisceralFatRating{ get; set; }
     public int PhysiqueRating { get; set; }

--- a/src/MiScaleExporter.MAUI/Models/GarminWeightExportData.cs
+++ b/src/MiScaleExporter.MAUI/Models/GarminWeightExportData.cs
@@ -1,0 +1,20 @@
+namespace MiScaleExporter.Models;
+
+/// <summary>
+/// Canonical Garmin weight payload used by direct upload, FIT generation, and the proxy API.
+/// </summary>
+public sealed record GarminWeightExportData
+{
+    public DateTime TimeStamp { get; init; }
+    public float Weight { get; init; }
+    public float PercentFat { get; init; }
+    public float PercentHydration { get; init; }
+    public float BoneMass { get; init; }
+    public float MuscleMass { get; init; }
+    public byte VisceralFatRating { get; init; }
+    public float VisceralFatMass { get; init; }
+    public byte PhysiqueRating { get; init; }
+    public byte MetabolicAge { get; init; }
+    public float BodyMassIndex { get; init; }
+    public float? BasalMet { get; init; }
+}

--- a/src/MiScaleExporter.MAUI/Models/GarminWeightExportData.cs
+++ b/src/MiScaleExporter.MAUI/Models/GarminWeightExportData.cs
@@ -10,7 +10,7 @@ public sealed record GarminWeightExportData
     public float PercentFat { get; init; }
     public float PercentHydration { get; init; }
     public float BoneMass { get; init; }
-    public float MuscleMass { get; init; }
+    public float SkeletalMuscleMass { get; init; }
     public byte VisceralFatRating { get; init; }
     public float VisceralFatMass { get; init; }
     public byte PhysiqueRating { get; init; }

--- a/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.Designer.cs
+++ b/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.Designer.cs
@@ -887,5 +887,95 @@ namespace MiScaleExporter.MAUI.Resources.Localization {
                 return ResourceManager.GetString("WeightLbs", resourceCulture);
             }
         }
+
+        internal static string S400DualFrequencyMetrics {
+            get {
+                return ResourceManager.GetString("S400DualFrequencyMetrics", resourceCulture);
+            }
+        }
+
+        internal static string Impedance250KHz {
+            get {
+                return ResourceManager.GetString("Impedance250KHz", resourceCulture);
+            }
+        }
+
+        internal static string Impedance50KHz {
+            get {
+                return ResourceManager.GetString("Impedance50KHz", resourceCulture);
+            }
+        }
+
+        internal static string LeanBodyMass {
+            get {
+                return ResourceManager.GetString("LeanBodyMass", resourceCulture);
+            }
+        }
+
+        internal static string ExtracellularWater {
+            get {
+                return ResourceManager.GetString("ExtracellularWater", resourceCulture);
+            }
+        }
+
+        internal static string IntracellularWater {
+            get {
+                return ResourceManager.GetString("IntracellularWater", resourceCulture);
+            }
+        }
+
+        internal static string EcwTbwRatio {
+            get {
+                return ResourceManager.GetString("EcwTbwRatio", resourceCulture);
+            }
+        }
+
+        internal static string BodyCellMass {
+            get {
+                return ResourceManager.GetString("BodyCellMass", resourceCulture);
+            }
+        }
+
+        internal static string SkeletalMuscleMass {
+            get {
+                return ResourceManager.GetString("SkeletalMuscleMass", resourceCulture);
+            }
+        }
+
+        internal static string SkeletalMuscleMassKg {
+            get {
+                return ResourceManager.GetString("SkeletalMuscleMassKg", resourceCulture);
+            }
+        }
+
+        internal static string SkeletalMuscleMassLbs {
+            get {
+                return ResourceManager.GetString("SkeletalMuscleMassLbs", resourceCulture);
+            }
+        }
+
+        internal static string SkeletalMuscleMassPer {
+            get {
+                return ResourceManager.GetString("SkeletalMuscleMassPer", resourceCulture);
+            }
+        }
+
+        internal static string SkeletalMuscleMassSentToGarmin {
+            get {
+                return ResourceManager.GetString("SkeletalMuscleMassSentToGarmin", resourceCulture);
+            }
+        }
+
+        internal static string TotalMuscleMass {
+            get {
+                return ResourceManager.GetString("TotalMuscleMass", resourceCulture);
+            }
+        }
+
+        internal static string HeartRate {
+            get {
+                return ResourceManager.GetString("HeartRate", resourceCulture);
+            }
+        }
     }
 }

--- a/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.pl.resx
+++ b/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.pl.resx
@@ -393,4 +393,49 @@
   <data name="WeightLbs" xml:space="preserve">
     <value>Waga (Lbs)</value>
   </data>
+  <data name="S400DualFrequencyMetrics" xml:space="preserve">
+    <value>Metryki S400 przechowywane lokalnie:</value>
+  </data>
+  <data name="Impedance250KHz" xml:space="preserve">
+    <value>Impedancja (250 kHz):</value>
+  </data>
+  <data name="Impedance50KHz" xml:space="preserve">
+    <value>Impedancja (50 kHz):</value>
+  </data>
+  <data name="LeanBodyMass" xml:space="preserve">
+    <value>Beztłuszczowa masa ciała:</value>
+  </data>
+  <data name="ExtracellularWater" xml:space="preserve">
+    <value>Woda zewnątrzkomórkowa:</value>
+  </data>
+  <data name="IntracellularWater" xml:space="preserve">
+    <value>Woda wewnątrzkomórkowa:</value>
+  </data>
+  <data name="EcwTbwRatio" xml:space="preserve">
+    <value>Stosunek ECW/TBW:</value>
+  </data>
+  <data name="BodyCellMass" xml:space="preserve">
+    <value>Masa komórkowa ciała:</value>
+  </data>
+  <data name="SkeletalMuscleMass" xml:space="preserve">
+    <value>Masa mięśni szkieletowych:</value>
+  </data>
+  <data name="SkeletalMuscleMassKg" xml:space="preserve">
+    <value>Masa mięśni szkieletowych (Kg)</value>
+  </data>
+  <data name="SkeletalMuscleMassLbs" xml:space="preserve">
+    <value>Masa mięśni szkieletowych (Lbs)</value>
+  </data>
+  <data name="SkeletalMuscleMassPer" xml:space="preserve">
+    <value>Masa mięśni szkieletowych (%)</value>
+  </data>
+  <data name="SkeletalMuscleMassSentToGarmin" xml:space="preserve">
+    <value>Dla pomiarów S400 edytowalna masa mięśni powyżej oznacza masę mięśni szkieletowych i zostanie wysłana do Garmin.</value>
+  </data>
+  <data name="TotalMuscleMass" xml:space="preserve">
+    <value>Całkowita masa mięśniowa:</value>
+  </data>
+  <data name="HeartRate" xml:space="preserve">
+    <value>Tętno:</value>
+  </data>
 </root>

--- a/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.resx
+++ b/src/MiScaleExporter.MAUI/Resources/Localization/AppSnippets.resx
@@ -396,4 +396,49 @@
   <data name="WeightLbs" xml:space="preserve">
     <value>Weight (Lbs)</value>
   </data>
+  <data name="S400DualFrequencyMetrics" xml:space="preserve">
+    <value>S400 metrics kept locally:</value>
+  </data>
+  <data name="Impedance250KHz" xml:space="preserve">
+    <value>Impedance (250 kHz):</value>
+  </data>
+  <data name="Impedance50KHz" xml:space="preserve">
+    <value>Impedance (50 kHz):</value>
+  </data>
+  <data name="LeanBodyMass" xml:space="preserve">
+    <value>Lean body mass:</value>
+  </data>
+  <data name="ExtracellularWater" xml:space="preserve">
+    <value>Extracellular water:</value>
+  </data>
+  <data name="IntracellularWater" xml:space="preserve">
+    <value>Intracellular water:</value>
+  </data>
+  <data name="EcwTbwRatio" xml:space="preserve">
+    <value>ECW/TBW ratio:</value>
+  </data>
+  <data name="BodyCellMass" xml:space="preserve">
+    <value>Body cell mass:</value>
+  </data>
+  <data name="SkeletalMuscleMass" xml:space="preserve">
+    <value>Skeletal muscle mass:</value>
+  </data>
+  <data name="SkeletalMuscleMassKg" xml:space="preserve">
+    <value>Skeletal Muscle Mass (Kg)</value>
+  </data>
+  <data name="SkeletalMuscleMassLbs" xml:space="preserve">
+    <value>Skeletal Muscle Mass (Lbs)</value>
+  </data>
+  <data name="SkeletalMuscleMassPer" xml:space="preserve">
+    <value>Skeletal Muscle Mass (%)</value>
+  </data>
+  <data name="SkeletalMuscleMassSentToGarmin" xml:space="preserve">
+    <value>For S400 measurements, the editable muscle mass above is skeletal muscle mass and will be sent to Garmin.</value>
+  </data>
+  <data name="TotalMuscleMass" xml:space="preserve">
+    <value>Total muscle mass:</value>
+  </data>
+  <data name="HeartRate" xml:space="preserve">
+    <value>Heart rate:</value>
+  </data>
 </root>

--- a/src/MiScaleExporter.MAUI/Services/DataInterpreter.cs
+++ b/src/MiScaleExporter.MAUI/Services/DataInterpreter.cs
@@ -1,23 +1,14 @@
-﻿using MiScaleBodyComposition.Contracts;
-using MiScaleExporter.Models;
+﻿using MiScaleExporter.Models;
 
 namespace MiScaleExporter.Services
 {
     public class DataInterpreter : IDataInterpreter
     {
-        private void ValidateAesKey(string aesKey)
+        private readonly S400DataInterpreter _s400DataInterpreter = new S400DataInterpreter();
+
+        public void ResetMeasurement()
         {
-            if (string.IsNullOrEmpty(aesKey) || aesKey.Length != 32)
-            {
-                throw new ArgumentException("AES key must be a 32-character hexadecimal string.");
-            }
-        }
-        private void ValidateBluetoothAddress(string btAddress)
-        {
-            if (string.IsNullOrEmpty(btAddress) || btAddress.Length != 17 || !btAddress.All(c => char.IsLetterOrDigit(c) || c == ':'))
-            {
-                throw new ArgumentException("Bluetooth address must be a valid 17-character string in the format XX:XX:XX:XX:XX:XX.");
-            }
+            _s400DataInterpreter.ResetMeasurement();
         }
 
         public BodyComposition ComputeData(byte[] data, User _user, string btAddress)
@@ -94,52 +85,9 @@ namespace MiScaleExporter.Services
                         return null;
                     }
                 case ScaleType.S400:
-
-                    if(data.Length == 26)
-                    {
-                        this.ValidateAesKey(_user.BindKey);
-                        this.ValidateBluetoothAddress(btAddress);
-
-                        var s400Scale = new MiScaleBodyComposition.S400Scale();
-                        var s400Result = s400Scale.GetBodyComposition(user, new S400InputData
-                        {
-                            Data = data,
-                            AesKey = _user.BindKey,
-                            MacOriginal = btAddress,
-                        });
-                        
-                        if (s400Result != null)
-                        {
-                            var bodyComposition = new BodyComposition
-                            {
-                                Weight = s400Result.Weight,
-                                BMI = s400Result.BMI,
-                                ProteinPercentage = s400Result.ProteinPercentage,
-                                IdealWeight = s400Result.IdealWeight,
-                                BMR = s400Result.BMR,
-                                BoneMass = s400Result.BoneMass,
-                                Fat = s400Result.Fat,
-                                MetabolicAge = s400Result.MetabolicAge,
-                                MuscleMass = s400Result.MuscleMass,
-                                VisceralFat = s400Result.VisceralFat,
-                                WaterPercentage = s400Result.Water,
-                                BodyType = s400Result.BodyType,
-                                HasImpedance = true,
-                                IsStabilized = true,
-                                Date = s400Result.Date,
-
-                            };
-                            return FatCalibration.ApplySaved(bodyComposition);
-
-                        }
-                    }
-                    var emptyBC = new BodyComposition
-                    {
-                        Weight = 0,
-                        HasImpedance = false,
-                        IsStabilized = false,
-                    };
-                    return emptyBC;
+                    // Keep the S400 model internally consistent. The legacy fat
+                    // calibration recalculates water and protein with single-frequency formulas.
+                    return _s400DataInterpreter.ComputeData(data, _user, btAddress);
 
                 default:
                     throw new NotImplementedException();

--- a/src/MiScaleExporter.MAUI/Services/GarminService.cs
+++ b/src/MiScaleExporter.MAUI/Services/GarminService.cs
@@ -88,20 +88,8 @@ public class GarminService : IGarminService
                 Height = Preferences.Get(PreferencesKeys.UserHeight, 170),
             };
 
-            var scaleDTO = new GarminWeightScaleDTO
-            {
-                TimeStamp = time,
-                Weight = Convert.ToSingle(bodyComposition.Weight),
-                PercentFat = Convert.ToSingle(bodyComposition.Fat),
-                PercentHydration = Convert.ToSingle(bodyComposition.WaterPercentage),
-                BoneMass = Convert.ToSingle(bodyComposition.BoneMass),
-                MuscleMass = Convert.ToSingle(bodyComposition.MuscleMass),
-                VisceralFatRating = Convert.ToByte(bodyComposition.VisceralFat),
-                VisceralFatMass = Convert.ToSingle(bodyComposition.VisceralFat),
-                PhysiqueRating = Convert.ToByte(bodyComposition.BodyType),
-                MetabolicAge = Convert.ToByte(bodyComposition.MetabolicAge),
-                BodyMassIndex = Convert.ToSingle(bodyComposition.BMI),
-            };
+            var exportData = GarminWeightExportMapper.Map(bodyComposition, time);
+            var scaleDTO = GarminWeightExportMapper.ToGarminDto(exportData);
 
             if (string.IsNullOrEmpty(bodyComposition.MFACode))
             {
@@ -157,21 +145,8 @@ public class GarminService : IGarminService
                 Height = Preferences.Get(PreferencesKeys.UserHeight, 170),
             };
 
-            var scaleDTO = new GarminWeightScaleDTO
-            {
-                TimeStamp = time,
-                Weight = Convert.ToSingle(bodyComposition.Weight),
-                PercentFat = Convert.ToSingle(bodyComposition.Fat),
-                PercentHydration = Convert.ToSingle(bodyComposition.WaterPercentage),
-                BoneMass = Convert.ToSingle(bodyComposition.BoneMass),
-                MuscleMass = Convert.ToSingle(bodyComposition.MuscleMass),
-                VisceralFatRating = Convert.ToByte(bodyComposition.VisceralFat),
-                VisceralFatMass = Convert.ToSingle(bodyComposition.VisceralFat),
-                PhysiqueRating = Convert.ToByte(bodyComposition.BodyType),
-                MetabolicAge = Convert.ToByte(bodyComposition.MetabolicAge),
-                BodyMassIndex = Convert.ToSingle(bodyComposition.BMI),
-               
-            };
+            var exportData = GarminWeightExportMapper.Map(bodyComposition, time);
+            var scaleDTO = GarminWeightExportMapper.ToGarminDto(exportData);
 
             _garminClient = await ClientFactory.Create();
 
@@ -200,24 +175,8 @@ public class GarminService : IGarminService
 
     private async Task<GarminApiResponse> UploadViaExternalAPIAsync(BodyComposition bodyComposition, DateTime time, CredentialsData credencials)
     {
-        var unixTime = ((DateTimeOffset)time).ToUnixTimeSeconds();
-        var request = new GarminBodyCompositionRequest
-        {
-            Email = credencials.Email,
-            Password = credencials.Password,
-            AccessToken = credencials.AccessToken,
-            TokenSecret = credencials.TokenSecret,
-            Weight = bodyComposition.Weight,
-            BoneMass = bodyComposition.BoneMass,
-            MuscleMass = bodyComposition.MuscleMass,
-            MetabolicAge = bodyComposition.MetabolicAge,
-            PercentFat = bodyComposition.Fat,
-            VisceralFatRating = bodyComposition.VisceralFat,
-            BodyMassIndex = bodyComposition.BMI,
-            PercentHydration = bodyComposition.WaterPercentage,
-            PhysiqueRating = bodyComposition.BodyType,
-            TimeStamp = unixTime,
-        };
+        var exportData = GarminWeightExportMapper.Map(bodyComposition, time);
+        var request = GarminWeightExportMapper.ToProxyRequest(exportData, credencials);
 
         if (!string.IsNullOrEmpty(bodyComposition.ExternalApiClientId))
         {

--- a/src/MiScaleExporter.MAUI/Services/GarminWeightExportMapper.cs
+++ b/src/MiScaleExporter.MAUI/Services/GarminWeightExportMapper.cs
@@ -9,7 +9,7 @@ public static class GarminWeightExportMapper
     {
         ArgumentNullException.ThrowIfNull(bodyComposition);
 
-        var muscleMass = bodyComposition.SkeletalMuscleMass ?? bodyComposition.MuscleMass;
+        var skeletalMuscleMass = bodyComposition.SkeletalMuscleMass ?? bodyComposition.MuscleMass;
 
         return new GarminWeightExportData
         {
@@ -18,7 +18,7 @@ public static class GarminWeightExportMapper
             PercentFat = Convert.ToSingle(bodyComposition.Fat),
             PercentHydration = Convert.ToSingle(bodyComposition.WaterPercentage),
             BoneMass = Convert.ToSingle(bodyComposition.BoneMass),
-            MuscleMass = Convert.ToSingle(muscleMass),
+            SkeletalMuscleMass = Convert.ToSingle(skeletalMuscleMass),
             VisceralFatRating = Convert.ToByte(bodyComposition.VisceralFat),
             VisceralFatMass = Convert.ToSingle(bodyComposition.VisceralFat),
             PhysiqueRating = Convert.ToByte(bodyComposition.BodyType),
@@ -41,7 +41,7 @@ public static class GarminWeightExportMapper
             PercentFat = data.PercentFat,
             PercentHydration = data.PercentHydration,
             BoneMass = data.BoneMass,
-            MuscleMass = data.MuscleMass,
+            SkeletalMuscleMass = data.SkeletalMuscleMass,
             VisceralFatRating = data.VisceralFatRating,
             VisceralFatMass = data.VisceralFatMass,
             PhysiqueRating = data.PhysiqueRating,
@@ -67,7 +67,8 @@ public static class GarminWeightExportMapper
             TokenSecret = credentials.TokenSecret,
             Weight = data.Weight,
             BoneMass = data.BoneMass,
-            MuscleMass = data.MuscleMass,
+            SkeletalMuscleMass = data.SkeletalMuscleMass,
+            MuscleMass = data.SkeletalMuscleMass,
             MetabolicAge = data.MetabolicAge,
             PercentFat = data.PercentFat,
             VisceralFatRating = data.VisceralFatRating,

--- a/src/MiScaleExporter.MAUI/Services/GarminWeightExportMapper.cs
+++ b/src/MiScaleExporter.MAUI/Services/GarminWeightExportMapper.cs
@@ -1,0 +1,83 @@
+using MiScaleExporter.Models;
+using YetAnotherGarminConnectClient.Dto.Garmin.Fit;
+
+namespace MiScaleExporter.Services;
+
+public static class GarminWeightExportMapper
+{
+    public static GarminWeightExportData Map(BodyComposition bodyComposition, DateTime time)
+    {
+        ArgumentNullException.ThrowIfNull(bodyComposition);
+
+        var muscleMass = bodyComposition.SkeletalMuscleMass ?? bodyComposition.MuscleMass;
+
+        return new GarminWeightExportData
+        {
+            TimeStamp = time,
+            Weight = Convert.ToSingle(bodyComposition.Weight),
+            PercentFat = Convert.ToSingle(bodyComposition.Fat),
+            PercentHydration = Convert.ToSingle(bodyComposition.WaterPercentage),
+            BoneMass = Convert.ToSingle(bodyComposition.BoneMass),
+            MuscleMass = Convert.ToSingle(muscleMass),
+            VisceralFatRating = Convert.ToByte(bodyComposition.VisceralFat),
+            VisceralFatMass = Convert.ToSingle(bodyComposition.VisceralFat),
+            PhysiqueRating = Convert.ToByte(bodyComposition.BodyType),
+            MetabolicAge = Convert.ToByte(bodyComposition.MetabolicAge),
+            BodyMassIndex = Convert.ToSingle(bodyComposition.BMI),
+            BasalMet = IsPositiveFinite(bodyComposition.BMR)
+                ? Convert.ToSingle(bodyComposition.BMR)
+                : null,
+        };
+    }
+
+    public static GarminWeightScaleDTO ToGarminDto(GarminWeightExportData data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        var dto = new GarminWeightScaleDTO
+        {
+            TimeStamp = data.TimeStamp,
+            Weight = data.Weight,
+            PercentFat = data.PercentFat,
+            PercentHydration = data.PercentHydration,
+            BoneMass = data.BoneMass,
+            MuscleMass = data.MuscleMass,
+            VisceralFatRating = data.VisceralFatRating,
+            VisceralFatMass = data.VisceralFatMass,
+            PhysiqueRating = data.PhysiqueRating,
+            MetabolicAge = data.MetabolicAge,
+            BodyMassIndex = data.BodyMassIndex,
+            BasalMet = data.BasalMet,
+        };
+        return dto;
+    }
+
+    public static GarminBodyCompositionRequest ToProxyRequest(
+        GarminWeightExportData data,
+        CredentialsData credentials)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentNullException.ThrowIfNull(credentials);
+
+        return new GarminBodyCompositionRequest
+        {
+            Email = credentials.Email,
+            Password = credentials.Password,
+            AccessToken = credentials.AccessToken,
+            TokenSecret = credentials.TokenSecret,
+            Weight = data.Weight,
+            BoneMass = data.BoneMass,
+            MuscleMass = data.MuscleMass,
+            MetabolicAge = data.MetabolicAge,
+            PercentFat = data.PercentFat,
+            VisceralFatRating = data.VisceralFatRating,
+            BodyMassIndex = data.BodyMassIndex,
+            PercentHydration = data.PercentHydration,
+            PhysiqueRating = data.PhysiqueRating,
+            BasalMet = data.BasalMet,
+            TimeStamp = ((DateTimeOffset)data.TimeStamp).ToUnixTimeSeconds(),
+        };
+    }
+
+    private static bool IsPositiveFinite(double value) => value > 0 && double.IsFinite(value);
+}

--- a/src/MiScaleExporter.MAUI/Services/IDataInterpreter.cs
+++ b/src/MiScaleExporter.MAUI/Services/IDataInterpreter.cs
@@ -5,5 +5,6 @@ namespace MiScaleExporter.Services
     public interface IDataInterpreter
     {
         BodyComposition ComputeData(byte[] data, User _user, string btAddress);
+        void ResetMeasurement();
     }
 }

--- a/src/MiScaleExporter.MAUI/Services/S400DataInterpreter.cs
+++ b/src/MiScaleExporter.MAUI/Services/S400DataInterpreter.cs
@@ -1,0 +1,112 @@
+using Xiaomi.BodyComposition.S400.Contracts;
+using MiScaleExporter.Models;
+using S400Library = Xiaomi.BodyComposition.S400;
+
+namespace MiScaleExporter.Services
+{
+    internal sealed class S400DataInterpreter
+    {
+        private readonly object _sync = new object();
+        private S400Library.S400Scale _scale = new S400Library.S400Scale();
+
+        public void ResetMeasurement()
+        {
+            lock (_sync)
+            {
+                _scale = new S400Library.S400Scale();
+            }
+        }
+
+        public BodyComposition ComputeData(byte[] data, User userInfo, string bluetoothAddress)
+        {
+            if (data == null || (data.Length != 24 && data.Length != 26))
+            {
+                return EmptyResult();
+            }
+
+            ValidateAesKey(userInfo.BindKey);
+            ValidateBluetoothAddress(bluetoothAddress);
+
+            var user = new S400Library.User(
+                userInfo.Height,
+                userInfo.Age,
+                (S400Library.Sex)(byte)userInfo.Sex);
+
+            S400Library.BodyComposition result;
+            lock (_sync)
+            {
+                result = _scale.GetBodyComposition(user, new S400InputData
+                {
+                    Data = data,
+                    AesKey = userInfo.BindKey,
+                    MacOriginal = bluetoothAddress,
+                });
+            }
+
+            if (result == null)
+            {
+                return EmptyResult();
+            }
+
+            var hasDualFrequencyImpedance = result.ImpedanceLow.HasValue
+                && result.ImpedanceHigh.HasValue
+                && result.LeanBodyMass.HasValue;
+
+            return new BodyComposition
+            {
+                Weight = result.Weight,
+                BMI = result.BMI,
+                ProteinPercentage = result.ProteinPercentage,
+                IdealWeight = result.IdealWeight,
+                BMR = result.BMR,
+                BoneMass = result.BoneMass,
+                Fat = result.Fat,
+                MetabolicAge = result.MetabolicAge,
+                MuscleMass = result.MuscleMass,
+                VisceralFat = result.VisceralFat,
+                WaterPercentage = result.Water,
+                BodyType = result.BodyType,
+                ImpedanceLow = result.ImpedanceLow,
+                ImpedanceHigh = result.ImpedanceHigh,
+                LeanBodyMass = result.LeanBodyMass,
+                ExtracellularWater = result.ExtracellularWater,
+                IntracellularWater = result.IntracellularWater,
+                EcwTbwRatio = result.EcwTbwRatio,
+                BodyCellMass = result.BodyCellMass,
+                SkeletalMuscleMass = result.SkeletalMuscleMass,
+                HeartRate = result.HeartRate,
+                HasImpedance = hasDualFrequencyImpedance,
+                IsStabilized = result.Weight > 0,
+                Date = result.Date,
+            };
+        }
+
+        private static BodyComposition EmptyResult()
+        {
+            return new BodyComposition
+            {
+                Weight = 0,
+                HasImpedance = false,
+                IsStabilized = false,
+            };
+        }
+
+        private static void ValidateAesKey(string aesKey)
+        {
+            if (string.IsNullOrEmpty(aesKey) || aesKey.Length != 32)
+            {
+                throw new ArgumentException("AES key must be a 32-character hexadecimal string.");
+            }
+        }
+
+        private static void ValidateBluetoothAddress(string bluetoothAddress)
+        {
+            if (string.IsNullOrEmpty(bluetoothAddress)
+                || bluetoothAddress.Length != 17
+                || !bluetoothAddress.All(c => char.IsLetterOrDigit(c) || c == ':'))
+            {
+                throw new ArgumentException("Bluetooth address must be a valid 17-character string in the format XX:XX:XX:XX:XX:XX.");
+            }
+        }
+    }
+}

--- a/src/MiScaleExporter.MAUI/Services/Scale.cs
+++ b/src/MiScaleExporter.MAUI/Services/Scale.cs
@@ -45,6 +45,7 @@ namespace MiScaleExporter.Services
 
         public async Task<BodyComposition> GetBodyCompositonAsync(string scaleAddress, User user)
         {
+            _dataInterpreter.ResetMeasurement();
             this.BodyComposition = null;
             _lastSuccessfulBodyComposition = null;
             _receivedBodyComposition = null;

--- a/src/MiScaleExporter.MAUI/ViewModels/FormViewModel.cs
+++ b/src/MiScaleExporter.MAUI/ViewModels/FormViewModel.cs
@@ -159,13 +159,32 @@ namespace MiScaleExporter.MAUI.ViewModels
 
         private BodyComposition PrepareRequest()
         {
+            var weight = ConvertToKg(DoubleValueParser.ParseValueFromUsersCulture(_weight) ?? 0);
+            var garminMuscleMass = DoubleValueParser.ParseValueFromUsersCulture(_muscleMass) ?? 0;
+            if (Preferences.Get(PreferencesKeys.MuscleMassAsPercentage, false)
+                && garminMuscleMass != 0
+                && weight != 0)
+            {
+                garminMuscleMass = (garminMuscleMass / 100) * weight;
+            }
+            else
+            {
+                garminMuscleMass = ConvertToKg(garminMuscleMass);
+            }
+
+            var displayedTotalMuscleMass = DoubleValueParser.ParseValueFromUsersCulture(_totalMuscleMass);
+            var totalMuscleMass = ShowS400Metrics && displayedTotalMuscleMass.HasValue
+                ? ConvertToKg(displayedTotalMuscleMass.Value)
+                : garminMuscleMass;
+
             var bc = new BodyComposition
             {
                 Fat = DoubleValueParser.ParseValueFromUsersCulture(_fat) ?? 0,
                 BodyType = _bodyType ?? 0,
-                Weight = ConvertToKg(DoubleValueParser.ParseValueFromUsersCulture(_weight) ?? 0),
+                Weight = weight,
                 BoneMass = ConvertToKg(DoubleValueParser.ParseValueFromUsersCulture(_boneMass) ?? 0),
-                MuscleMass = ConvertToKg(DoubleValueParser.ParseValueFromUsersCulture(_muscleMass) ?? 0),
+                MuscleMass = totalMuscleMass,
+                SkeletalMuscleMass = ShowS400Metrics ? garminMuscleMass : null,
                 MetabolicAge = DoubleValueParser.ParseValueFromUsersCulture(_metabolicAge) ?? 0,
                 ProteinPercentage = DoubleValueParser.ParseValueFromUsersCulture(_proteinPercentage) ?? 0,
                 VisceralFat = DoubleValueParser.ParseValueFromUsersCulture(_visceralFat) ?? 0,
@@ -175,13 +194,6 @@ namespace MiScaleExporter.MAUI.ViewModels
                 MFACode = _mfaCode,
                 ExternalApiClientId = _externalApiClientId
             };
-
-            if (Preferences.Get(PreferencesKeys.MuscleMassAsPercentage, false) 
-                && bc.MuscleMass != 0 
-                && bc.Weight != 0)
-            {
-                bc.MuscleMass = (bc.MuscleMass / 100) * bc.Weight;
-            }
             return bc;
         }
 
@@ -192,7 +204,6 @@ namespace MiScaleExporter.MAUI.ViewModels
             Weight = ConvertFromKg(App.BodyComposition.Weight).ToString("0.##");
             BMI = App.BodyComposition.BMI.ToString();
             BoneMass = ConvertFromKg(App.BodyComposition.BoneMass).ToString("0.##");
-            MuscleMass = ConvertFromKg(App.BodyComposition.MuscleMass).ToString("0.##");
             IdealWeight = ConvertFromKg(App.BodyComposition.IdealWeight).ToString("0.##");
             BMR = App.BodyComposition.BMR.ToString();
             MetabolicAge = App.BodyComposition.MetabolicAge.ToString();
@@ -201,6 +212,25 @@ namespace MiScaleExporter.MAUI.ViewModels
             Fat = App.BodyComposition.Fat.ToString();
             WaterPercentage = App.BodyComposition.WaterPercentage.ToString();
             BodyType = App.BodyComposition.BodyType;
+            ShowS400Metrics = App.BodyComposition.HasDualFrequencyImpedance;
+            var garminMuscleMass = App.BodyComposition.SkeletalMuscleMass ?? App.BodyComposition.MuscleMass;
+            MuscleMass = FormatMuscleMassForEntry(garminMuscleMass, App.BodyComposition.Weight);
+            if (ShowS400Metrics)
+            {
+                TotalMuscleMass = ConvertFromKg(App.BodyComposition.MuscleMass).ToString("0.##");
+                HeartRate = App.BodyComposition.HeartRate?.ToString("0");
+                ImpedanceLow = App.BodyComposition.ImpedanceLow?.ToString("0.0");
+                ImpedanceHigh = App.BodyComposition.ImpedanceHigh?.ToString("0.0");
+                LeanBodyMass = App.BodyComposition.LeanBodyMass.HasValue
+                    ? ConvertFromKg(App.BodyComposition.LeanBodyMass.Value).ToString("0.##")
+                    : null;
+                ExtracellularWater = App.BodyComposition.ExtracellularWater?.ToString("0.##");
+                IntracellularWater = App.BodyComposition.IntracellularWater?.ToString("0.##");
+                EcwTbwRatio = App.BodyComposition.EcwTbwRatio?.ToString("0.#");
+                BodyCellMass = App.BodyComposition.BodyCellMass.HasValue
+                    ? ConvertFromKg(App.BodyComposition.BodyCellMass.Value).ToString("0.##")
+                    : null;
+            }
             IsAutomaticCalculation = true;
         }
 
@@ -304,6 +334,78 @@ namespace MiScaleExporter.MAUI.ViewModels
             get => _waterPercentage;
             set => SetProperty(ref _waterPercentage, DoubleValueParser.CheckValue(value));
         }
+
+        private bool _showS400Metrics;
+        public bool ShowS400Metrics
+        {
+            get => _showS400Metrics;
+            set => SetProperty(ref _showS400Metrics, value);
+        }
+
+        private string _impedanceLow;
+        public string ImpedanceLow
+        {
+            get => _impedanceLow;
+            set => SetProperty(ref _impedanceLow, value);
+        }
+
+        private string _impedanceHigh;
+        public string ImpedanceHigh
+        {
+            get => _impedanceHigh;
+            set => SetProperty(ref _impedanceHigh, value);
+        }
+
+        private string _leanBodyMass;
+        public string LeanBodyMass
+        {
+            get => _leanBodyMass;
+            set => SetProperty(ref _leanBodyMass, value);
+        }
+
+        private string _extracellularWater;
+        public string ExtracellularWater
+        {
+            get => _extracellularWater;
+            set => SetProperty(ref _extracellularWater, value);
+        }
+
+        private string _intracellularWater;
+        public string IntracellularWater
+        {
+            get => _intracellularWater;
+            set => SetProperty(ref _intracellularWater, value);
+        }
+
+        private string _ecwTbwRatio;
+        public string EcwTbwRatio
+        {
+            get => _ecwTbwRatio;
+            set => SetProperty(ref _ecwTbwRatio, value);
+        }
+
+        private string _bodyCellMass;
+        public string BodyCellMass
+        {
+            get => _bodyCellMass;
+            set => SetProperty(ref _bodyCellMass, value);
+        }
+
+        private string _totalMuscleMass;
+        public string TotalMuscleMass
+        {
+            get => _totalMuscleMass;
+            set => SetProperty(ref _totalMuscleMass, value);
+        }
+
+        private string _heartRate;
+        public string HeartRate
+        {
+            get => _heartRate;
+            set => SetProperty(ref _heartRate, value);
+        }
+
+        public string MassUnit => _displayWeightInLbs ? "lbs" : "kg";
 
         private string _email;
 
@@ -414,6 +516,16 @@ namespace MiScaleExporter.MAUI.ViewModels
         private double ConvertToKg(double displayValue)
         {
             return _displayWeightInLbs ? displayValue / KgToLbsConversion : displayValue;
+        }
+
+        private string FormatMuscleMassForEntry(double muscleMassKg, double weightKg)
+        {
+            if (MuscleMassAsPercentage && weightKg > 0)
+            {
+                return ((muscleMassKg / weightKg) * 100).ToString("0.##");
+            }
+
+            return ConvertFromKg(muscleMassKg).ToString("0.##");
         }
 
         private bool _displayWeightInLbs;

--- a/src/MiScaleExporter.MAUI/Views/FormPage.xaml
+++ b/src/MiScaleExporter.MAUI/Views/FormPage.xaml
@@ -98,9 +98,9 @@ AdSize="SmartBanner"
                             </Entry>
                         </StackLayout>
                         <StackLayout Grid.Row="2" Grid.Column="1">
-                            <Label FontSize="Small" Text="{x:Static localization:AppSnippets.MuscleMassLbs}" IsVisible="{Binding MuscleMassAsLbs}" />
-                            <Label FontSize="Small" Text="{x:Static localization:AppSnippets.MuscleMassKg}" IsVisible="{Binding MuscleMassAsKg}" />
-                            <Label FontSize="Small" Text="{x:Static localization:AppSnippets.MuscleMassPer}" IsVisible="{Binding MuscleMassAsPercentage}" />
+                            <Label FontSize="Small" Text="{x:Static localization:AppSnippets.SkeletalMuscleMassLbs}" IsVisible="{Binding MuscleMassAsLbs}" />
+                            <Label FontSize="Small" Text="{x:Static localization:AppSnippets.SkeletalMuscleMassKg}" IsVisible="{Binding MuscleMassAsKg}" />
+                            <Label FontSize="Small" Text="{x:Static localization:AppSnippets.SkeletalMuscleMassPer}" IsVisible="{Binding MuscleMassAsPercentage}" />
                             <Entry
                         FontSize="Medium"
                         Keyboard="Numeric"
@@ -271,6 +271,17 @@ AdSize="SmartBanner"
                                 IsVisible="{Binding ShowMFACode}"/>
 
                             <StackLayout IsVisible="{Binding IsAutomaticCalculation}">
+                                <StackLayout Orientation="Horizontal">
+                                    <Label FontSize="Small" Text="{x:Static localization:AppSnippets.BasalMetabolosimKCal}" />
+                                    <Entry
+                                        FontSize="Small"
+                                        Keyboard="Numeric"
+                                        Text="{Binding BMR, Mode=TwoWay}" />
+                                </StackLayout>
+                                <Label
+                                    FontSize="Small"
+                                    IsVisible="{Binding ShowS400Metrics}"
+                                    Text="{x:Static localization:AppSnippets.SkeletalMuscleMassSentToGarmin}" />
                                 <Label FontSize="Small" Text="{x:Static localization:AppSnippets.ValuesThatWillNotBeSentToTheCloud}" />
                                 <StackLayout Orientation="Horizontal">
                                     <Label FontSize="Small" Text="{x:Static localization:AppSnippets.ProteinPercent}" />
@@ -278,14 +289,58 @@ AdSize="SmartBanner"
 
                                 </StackLayout>
                                 <StackLayout Orientation="Horizontal">
-                                    <Label FontSize="Small" Text="{x:Static localization:AppSnippets.BasalMetabolosimKCal}" />
-                                    <Label FontSize="Small" Text="{Binding BMR, Mode=TwoWay}" />
-                                </StackLayout>
-                                <StackLayout Orientation="Horizontal">
                                     <Label FontSize="Small" Text="{x:Static localization:AppSnippets.IdealWeightKg}" IsVisible="{Binding ShowWeightInKg}" />
                                     <Label FontSize="Small" Text="{x:Static localization:AppSnippets.IdealWeightLbs}" IsVisible="{Binding ShowWeightInLbs}" />
                                     <Label FontSize="Small" Text="{Binding IdealWeight, Mode=TwoWay}" />
 
+                                </StackLayout>
+                                <StackLayout Margin="0,8,0,0" IsVisible="{Binding ShowS400Metrics}">
+                                    <Label FontAttributes="Bold" FontSize="Small" Text="{x:Static localization:AppSnippets.S400DualFrequencyMetrics}" />
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.TotalMuscleMass}" />
+                                        <Label FontSize="Small" Text="{Binding TotalMuscleMass}" />
+                                        <Label FontSize="Small" Text="{Binding MassUnit, StringFormat=' {0}'}" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.HeartRate}" />
+                                        <Label FontSize="Small" Text="{Binding HeartRate}" />
+                                        <Label FontSize="Small" Text=" bpm" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.Impedance250KHz}" />
+                                        <Label FontSize="Small" Text="{Binding ImpedanceLow}" />
+                                        <Label FontSize="Small" Text=" Ω" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.Impedance50KHz}" />
+                                        <Label FontSize="Small" Text="{Binding ImpedanceHigh}" />
+                                        <Label FontSize="Small" Text=" Ω" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.LeanBodyMass}" />
+                                        <Label FontSize="Small" Text="{Binding LeanBodyMass}" />
+                                        <Label FontSize="Small" Text="{Binding MassUnit, StringFormat=' {0}'}" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.ExtracellularWater}" />
+                                        <Label FontSize="Small" Text="{Binding ExtracellularWater}" />
+                                        <Label FontSize="Small" Text=" L" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.IntracellularWater}" />
+                                        <Label FontSize="Small" Text="{Binding IntracellularWater}" />
+                                        <Label FontSize="Small" Text=" L" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.EcwTbwRatio}" />
+                                        <Label FontSize="Small" Text="{Binding EcwTbwRatio}" />
+                                        <Label FontSize="Small" Text=" %" />
+                                    </StackLayout>
+                                    <StackLayout Orientation="Horizontal">
+                                        <Label FontSize="Small" Text="{x:Static localization:AppSnippets.BodyCellMass}" />
+                                        <Label FontSize="Small" Text="{Binding BodyCellMass}" />
+                                        <Label FontSize="Small" Text="{Binding MassUnit, StringFormat=' {0}'}" />
+                                    </StackLayout>
                                 </StackLayout>
                             </StackLayout>
 

--- a/tests/MiScaleExporter.UnitTests/GarminWeightExportMapperTests.cs
+++ b/tests/MiScaleExporter.UnitTests/GarminWeightExportMapperTests.cs
@@ -1,0 +1,87 @@
+using MiScaleExporter.Models;
+using MiScaleExporter.Services;
+using NUnit.Framework;
+using YetAnotherGarminConnectClient.Dto.Garmin.Fit;
+
+namespace MiScaleExporter.UnitTests;
+
+[TestFixture]
+public class GarminWeightExportMapperTests
+{
+    private static readonly DateTime MeasurementTime =
+        new(2026, 7, 12, 8, 30, 0, DateTimeKind.Utc);
+
+    [Test]
+    public void S400UsesSkeletalMuscleMassAndBasalMetAcrossAllPayloads()
+    {
+        var bodyComposition = CreateBodyComposition();
+        bodyComposition.MuscleMass = 58.6;
+        bodyComposition.SkeletalMuscleMass = 40.0;
+        bodyComposition.BMR = 1702;
+
+        var export = GarminWeightExportMapper.Map(bodyComposition, MeasurementTime);
+        var direct = GarminWeightExportMapper.ToGarminDto(export);
+        var proxy = GarminWeightExportMapper.ToProxyRequest(export, new CredentialsData
+        {
+            Email = "user@example.com",
+            Password = "password",
+        });
+
+        Assert.That(export.MuscleMass, Is.EqualTo(40.0f));
+        Assert.That(export.BasalMet, Is.EqualTo(1702f));
+        Assert.That(direct.MuscleMass, Is.EqualTo(export.MuscleMass));
+        Assert.That(direct.BasalMet, Is.EqualTo(1702f));
+        Assert.That(proxy.MuscleMass, Is.EqualTo(export.MuscleMass));
+        Assert.That(proxy.BasalMet, Is.EqualTo(export.BasalMet));
+        Assert.That(proxy.TimeStamp, Is.EqualTo(new DateTimeOffset(MeasurementTime).ToUnixTimeSeconds()));
+    }
+
+    [Test]
+    public void LegacyMeasurementUsesTotalMuscleMass()
+    {
+        var bodyComposition = CreateBodyComposition();
+        bodyComposition.MuscleMass = 58.6;
+        bodyComposition.SkeletalMuscleMass = null;
+
+        var export = GarminWeightExportMapper.Map(bodyComposition, MeasurementTime);
+
+        Assert.That(export.MuscleMass, Is.EqualTo(58.6f).Within(0.001f));
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void NonPositiveBmrIsOmitted(double bmr)
+    {
+        var bodyComposition = CreateBodyComposition();
+        bodyComposition.BMR = bmr;
+
+        var export = GarminWeightExportMapper.Map(bodyComposition, MeasurementTime);
+
+        Assert.That(export.BasalMet, Is.Null);
+    }
+
+    [Test]
+    public void NonFiniteBmrIsOmitted()
+    {
+        var bodyComposition = CreateBodyComposition();
+        bodyComposition.BMR = double.NaN;
+
+        var export = GarminWeightExportMapper.Map(bodyComposition, MeasurementTime);
+
+        Assert.That(export.BasalMet, Is.Null);
+    }
+
+    private static BodyComposition CreateBodyComposition() => new()
+    {
+        Weight = 74.2,
+        Fat = 16.9,
+        WaterPercentage = 60.7,
+        BoneMass = 3.1,
+        MuscleMass = 58.6,
+        VisceralFat = 7,
+        BodyType = 5,
+        MetabolicAge = 30,
+        BMI = 22.4,
+        BMR = 1702,
+    };
+}

--- a/tests/MiScaleExporter.UnitTests/GarminWeightExportMapperTests.cs
+++ b/tests/MiScaleExporter.UnitTests/GarminWeightExportMapperTests.cs
@@ -27,11 +27,12 @@ public class GarminWeightExportMapperTests
             Password = "password",
         });
 
-        Assert.That(export.MuscleMass, Is.EqualTo(40.0f));
+        Assert.That(export.SkeletalMuscleMass, Is.EqualTo(40.0f));
         Assert.That(export.BasalMet, Is.EqualTo(1702f));
-        Assert.That(direct.MuscleMass, Is.EqualTo(export.MuscleMass));
+        Assert.That(direct.SkeletalMuscleMass, Is.EqualTo(export.SkeletalMuscleMass));
         Assert.That(direct.BasalMet, Is.EqualTo(1702f));
-        Assert.That(proxy.MuscleMass, Is.EqualTo(export.MuscleMass));
+        Assert.That(proxy.SkeletalMuscleMass, Is.EqualTo(export.SkeletalMuscleMass));
+        Assert.That(proxy.MuscleMass, Is.EqualTo(export.SkeletalMuscleMass));
         Assert.That(proxy.BasalMet, Is.EqualTo(export.BasalMet));
         Assert.That(proxy.TimeStamp, Is.EqualTo(new DateTimeOffset(MeasurementTime).ToUnixTimeSeconds()));
     }
@@ -45,7 +46,7 @@ public class GarminWeightExportMapperTests
 
         var export = GarminWeightExportMapper.Map(bodyComposition, MeasurementTime);
 
-        Assert.That(export.MuscleMass, Is.EqualTo(58.6f).Within(0.001f));
+        Assert.That(export.SkeletalMuscleMass, Is.EqualTo(58.6f).Within(0.001f));
     }
 
     [TestCase(0)]

--- a/tests/MiScaleExporter.UnitTests/MiScaleExporter.UnitTests.csproj
+++ b/tests/MiScaleExporter.UnitTests/MiScaleExporter.UnitTests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="Xiaomi.BodyComposition.S400" Version="1.1.1" Condition="!Exists('$(XiaomiBodyCompositionS400Project)')" />
+    <PackageReference Include="YetAnotherGarminConnectClient" Version="0.0.18" Condition="!Exists('$(YetAnotherGarminConnectClientProject)')" />
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(XiaomiBodyCompositionS400Project)')">
+    <ProjectReference Include="$(XiaomiBodyCompositionS400Project)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(YetAnotherGarminConnectClientProject)')">
+    <ProjectReference Include="$(YetAnotherGarminConnectClientProject)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Models\BodyComposition.cs" Link="Models\BodyComposition.cs" />
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Models\GarminBodyCompositionRequest.cs" Link="Models\GarminBodyCompositionRequest.cs" />
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Models\GarminWeightExportData.cs" Link="Models\GarminWeightExportData.cs" />
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Models\ScaleType.cs" Link="Models\ScaleType.cs" />
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Models\Sex.cs" Link="Models\Sex.cs" />
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Models\User.cs" Link="Models\User.cs" />
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Services\S400DataInterpreter.cs" Link="Services\S400DataInterpreter.cs" />
+    <Compile Include="..\..\src\MiScaleExporter.MAUI\Services\GarminWeightExportMapper.cs" Link="Services\GarminWeightExportMapper.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/MiScaleExporter.UnitTests/S400DataInterpreterTests.cs
+++ b/tests/MiScaleExporter.UnitTests/S400DataInterpreterTests.cs
@@ -1,0 +1,89 @@
+using MiScaleExporter.Models;
+using MiScaleExporter.Services;
+using NUnit.Framework;
+
+namespace MiScaleExporter.UnitTests
+{
+    [TestFixture]
+    public class S400DataInterpreterTests
+    {
+        private const string BluetoothAddress = "84:46:93:64:A5:E6";
+        private const string BindKey = "58305740b64e4b425e518aa1f4e51339";
+        private const string ImpedanceLowPacket = "4859d53b2e724a8c783dc8a392c10db411000000a8a7bad5";
+        private const string ImpedanceHighPacket = "4859d53b2d3314943c58b133638c7457a4000000c3e670dc";
+
+        private static User CreateUser()
+        {
+            return new User
+            {
+                Height = 182,
+                Age = 29,
+                Sex = Sex.Male,
+                ScaleType = ScaleType.S400,
+                BindKey = BindKey,
+            };
+        }
+
+        [Test]
+        public void ComputesFullS400MetricsFromBothAdvertisements()
+        {
+            var interpreter = new S400DataInterpreter();
+            var user = CreateUser();
+
+            var pending = interpreter.ComputeData(Convert.FromHexString(ImpedanceLowPacket), user, BluetoothAddress);
+            var result = interpreter.ComputeData(Convert.FromHexString(ImpedanceHighPacket), user, BluetoothAddress);
+
+            Assert.AreEqual(0, pending.Weight);
+            Assert.IsFalse(pending.HasImpedance);
+            Assert.AreEqual(74.2, result.Weight);
+            Assert.IsTrue(result.HasImpedance);
+            Assert.IsTrue(result.HasDualFrequencyImpedance);
+            Assert.AreEqual(360.0, result.ImpedanceLow);
+            Assert.AreEqual(400.9, result.ImpedanceHigh);
+            Assert.AreEqual(61.7, result.LeanBodyMass);
+            Assert.AreEqual(16.9, result.Fat);
+            Assert.AreEqual(60.7, result.WaterPercentage);
+            Assert.AreEqual(17.64, result.ExtracellularWater);
+            Assert.AreEqual(27.38, result.IntracellularWater);
+            Assert.AreEqual(39.2, result.EcwTbwRatio);
+            Assert.AreEqual(37.51, result.BodyCellMass);
+            Assert.AreEqual(40.00, result.SkeletalMuscleMass);
+            Assert.AreEqual(16.2, result.ProteinPercentage);
+            Assert.AreEqual(1702, result.BMR);
+            Assert.AreEqual(30, result.MetabolicAge);
+            Assert.Greater(result.MuscleMass, result.SkeletalMuscleMass);
+            Assert.That(result.HeartRate, Is.Not.Null.And.GreaterThan(0));
+        }
+
+        [Test]
+        public void WaitsForBothFrequenciesWhenWeightArrivesFirst()
+        {
+            var interpreter = new S400DataInterpreter();
+            var user = CreateUser();
+
+            var pending = interpreter.ComputeData(Convert.FromHexString(ImpedanceHighPacket), user, BluetoothAddress);
+            var result = interpreter.ComputeData(Convert.FromHexString(ImpedanceLowPacket), user, BluetoothAddress);
+
+            Assert.AreEqual(74.2, pending.Weight);
+            Assert.IsFalse(pending.HasImpedance);
+            Assert.IsNull(pending.LeanBodyMass);
+            Assert.IsTrue(result.HasImpedance);
+            Assert.AreEqual(61.7, result.LeanBodyMass);
+        }
+
+        [Test]
+        public void ResetPreventsAnIncompleteReadingFromLeakingIntoTheNextScan()
+        {
+            var interpreter = new S400DataInterpreter();
+            var user = CreateUser();
+
+            interpreter.ComputeData(Convert.FromHexString(ImpedanceHighPacket), user, BluetoothAddress);
+            interpreter.ResetMeasurement();
+            var result = interpreter.ComputeData(Convert.FromHexString(ImpedanceLowPacket), user, BluetoothAddress);
+
+            Assert.AreEqual(0, result.Weight);
+            Assert.IsFalse(result.HasImpedance);
+            Assert.IsFalse(result.HasDualFrequencyImpedance);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- complete Xiaomi S400 dual-frequency acquisition and display
- export S400 skeletal muscle mass through Garmin muscle_mass and name it SkeletalMuscleMass in application and library models
- export positive BMR through Garmin basal_met
- keep unsupported S400 metrics local, including heart rate and total muscle mass
- centralize direct upload, FIT generation, and proxy payload mapping
- send both SkeletalMuscleMass and legacy MuscleMass to the proxy during the deployment transition
- label the Garmin-bound field as Skeletal Muscle Mass and populate it from S400 SMM

Fixes #55

## Dependencies

- Requires https://github.com/lswiderski/yet-another-garmin-connect-client/pull/16
- Requires Xiaomi.BodyComposition.S400 1.1.1
- Requires YetAnotherGarminConnectClient 0.0.18 and matching proxy deployment

## Verification

- 8/8 unit tests pass against the updated YAGCC project
- FIT round-trip preserves basal_met=1702 and muscle_mass=40
- Android Debug build against the updated YAGCC project succeeds with 0 errors
- rebuilt YAGCC 0.0.18 candidate package contains SkeletalMuscleMass, legacy MuscleMass, and BasalMet